### PR TITLE
[codex] Speed up audio pipeline

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/DictateController.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/DictateController.kt
@@ -32,6 +32,7 @@ import dev.patrickgold.florisboard.app.FlorisPreferenceStore
 import dev.patrickgold.florisboard.dictate.audio.AudioConcat
 import dev.patrickgold.florisboard.dictate.audio.AudioDecode
 import dev.patrickgold.florisboard.dictate.audio.BluetoothMicRouter
+import dev.patrickgold.florisboard.dictate.audio.Pcm16Resampler
 import dev.patrickgold.florisboard.dictate.audio.RecordingController
 import dev.patrickgold.florisboard.dictate.audio.SpeechGate
 import dev.patrickgold.florisboard.dictate.data.prompts.DictatePromptDefaults
@@ -929,8 +930,13 @@ object DictateController {
             .getOrElse { realtimeFailed = true; null } ?: return null
         realtimeSession = session
         val targetRate = RealtimeClient.sampleRateFor(api)
+        if (targetRate == AudioDecode.TARGET_SAMPLE_RATE) {
+            return { pcm, len ->
+                runCatching { session.sendAudio(pcm, len) }
+            }
+        }
         return { pcm, len ->
-            val out = resamplePcm16(pcm, len, AudioDecode.TARGET_SAMPLE_RATE, targetRate)
+            val out = Pcm16Resampler.resample(pcm, len, AudioDecode.TARGET_SAMPLE_RATE, targetRate)
             runCatching { session.sendAudio(out, out.size) }
         }
     }
@@ -997,33 +1003,6 @@ object DictateController {
                 }
             }
         }
-    }
-
-    /** Linear 16-bit PCM resampler (used to lift 16 kHz mic frames to a provider's rate, e.g. OpenAI 24 kHz). */
-    private fun resamplePcm16(pcm: ByteArray, len: Int, srcRate: Int, dstRate: Int): ByteArray {
-        if (srcRate == dstRate) return if (len == pcm.size) pcm else pcm.copyOf(len)
-        val inSamples = len / 2
-        if (inSamples <= 0) return ByteArray(0)
-        val outSamples = (inSamples.toLong() * dstRate / srcRate).toInt().coerceAtLeast(1)
-        val out = ByteArray(outSamples * 2)
-        for (i in 0 until outSamples) {
-            val srcPos = i.toDouble() * srcRate / dstRate
-            val i0 = srcPos.toInt()
-            val frac = srcPos - i0
-            val s0 = pcmSampleAt(pcm, i0, inSamples)
-            val s1 = pcmSampleAt(pcm, i0 + 1, inSamples)
-            val v = (s0 + (s1 - s0) * frac).toInt().coerceIn(-32768, 32767)
-            out[i * 2] = (v and 0xff).toByte()
-            out[i * 2 + 1] = ((v shr 8) and 0xff).toByte()
-        }
-        return out
-    }
-
-    private fun pcmSampleAt(pcm: ByteArray, idx: Int, count: Int): Int {
-        val i = idx.coerceIn(0, count - 1)
-        val lo = pcm[i * 2].toInt() and 0xff
-        val hi = pcm[i * 2 + 1].toInt()
-        return (hi shl 8) or lo
     }
 
     // --- Output behavior + resend (roadmap section 10) ------------------------------------------

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/AudioConcat.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/AudioConcat.kt
@@ -48,11 +48,14 @@ object AudioConcat {
                 out.setLength(0)
                 out.write(ByteArray(WAV_HEADER_SIZE)) // placeholder; patched once totals are known
                 for (segment in usable) {
-                    val bytes = segment.readBytes()
-                    val parsed = parseWav(bytes) ?: continue
+                    val parsed = RandomAccessFile(segment, "r").use { input ->
+                        parseWav(input)?.also {
+                            if (fmt == null) fmt = it.fmt
+                            input.seek(it.dataOffset)
+                            dataBytes += copy(input, out, it.dataLength)
+                        }
+                    } ?: continue
                     if (fmt == null) fmt = parsed.fmt
-                    out.write(bytes, parsed.dataOffset, parsed.dataLength)
-                    dataBytes += parsed.dataLength
                 }
                 val format = fmt
                 if (format == null || dataBytes <= 0L) {
@@ -69,39 +72,58 @@ object AudioConcat {
         return output.exists() && output.length() > WAV_HEADER_SIZE
     }
 
-    private class ParsedWav(val fmt: WavFmt, val dataOffset: Int, val dataLength: Int)
+    private class ParsedWav(val fmt: WavFmt, val dataOffset: Long, val dataLength: Long)
 
-    /** Parses a PCM WAV's `fmt `/`data` chunks, or returns null if [bytes] is not a usable WAV. */
-    private fun parseWav(bytes: ByteArray): ParsedWav? {
-        if (bytes.size < WAV_HEADER_SIZE) return null
-        fun tag(off: Int) = String(bytes, off, 4, Charsets.US_ASCII)
-        if (tag(0) != "RIFF" || tag(8) != "WAVE") return null
-        fun le16(off: Int) = (bytes[off].toInt() and 0xff) or ((bytes[off + 1].toInt() and 0xff) shl 8)
-        fun le32(off: Int) = (bytes[off].toInt() and 0xff) or ((bytes[off + 1].toInt() and 0xff) shl 8) or
-            ((bytes[off + 2].toInt() and 0xff) shl 16) or ((bytes[off + 3].toInt() and 0xff) shl 24)
+    /** Parses a PCM WAV's `fmt `/`data` chunks, or returns null if [input] is not a usable WAV. */
+    private fun parseWav(input: RandomAccessFile): ParsedWav? {
+        if (input.length() < WAV_HEADER_SIZE) return null
+        val header = ByteArray(12)
+        input.readFully(header)
+        if (!header.hasTag(0, "RIFF") || !header.hasTag(8, "WAVE")) return null
 
         var fmt: WavFmt? = null
-        var p = 12 // after "RIFF"<size>"WAVE"
-        while (p + 8 <= bytes.size) {
-            val id = tag(p)
-            val size = le32(p + 4)
-            val body = p + 8
-            when (id) {
-                "fmt " -> fmt = WavFmt(
-                    sampleRate = le32(body + 4),
-                    channels = le16(body + 2).coerceAtLeast(1),
-                    bitsPerSample = le16(body + 14),
-                )
-                "data" -> {
-                    val len = size.coerceAtMost(bytes.size - body)
+        val chunkHeader = ByteArray(8)
+        while (input.filePointer + chunkHeader.size <= input.length()) {
+            input.readFully(chunkHeader)
+            val size = chunkHeader.le32(4).toLong() and 0xffff_ffffL
+            val body = input.filePointer
+            when {
+                chunkHeader.hasTag(0, "fmt ") -> {
+                    if (size >= 16L && body + 16L <= input.length()) {
+                        val bytes = ByteArray(16)
+                        input.readFully(bytes)
+                        fmt = WavFmt(
+                            sampleRate = bytes.le32(4),
+                            channels = bytes.le16(2).coerceAtLeast(1),
+                            bitsPerSample = bytes.le16(14),
+                        )
+                    }
+                }
+                chunkHeader.hasTag(0, "data") -> {
                     val f = fmt ?: return null
-                    if (len <= 0) return null
+                    val len = size.coerceAtMost(input.length() - body)
+                    if (len <= 0L) return null
                     return ParsedWav(f, body, len)
                 }
             }
-            p = body + size + (size and 1) // chunks are word-aligned
+            val next = (body + size + (size and 1L)).coerceAtMost(input.length())
+            input.seek(next)
         }
         return null
+    }
+
+    private fun copy(input: RandomAccessFile, output: RandomAccessFile, length: Long): Long {
+        val buffer = ByteArray(COPY_BUFFER_SIZE)
+        var remaining = length
+        var written = 0L
+        while (remaining > 0L) {
+            val read = input.read(buffer, 0, minOf(buffer.size.toLong(), remaining).toInt())
+            if (read < 0) break
+            output.write(buffer, 0, read)
+            written += read
+            remaining -= read
+        }
+        return written
     }
 
     private fun wavHeader(fmt: WavFmt, dataLen: Long): ByteArray {
@@ -122,4 +144,21 @@ object AudioConcat {
             putInt(dataLen.toInt())
         }.array()
     }
+
+    private fun ByteArray.hasTag(offset: Int, tag: String): Boolean =
+        this[offset] == tag[0].code.toByte() &&
+            this[offset + 1] == tag[1].code.toByte() &&
+            this[offset + 2] == tag[2].code.toByte() &&
+            this[offset + 3] == tag[3].code.toByte()
+
+    private fun ByteArray.le16(offset: Int): Int =
+        (this[offset].toInt() and 0xff) or ((this[offset + 1].toInt() and 0xff) shl 8)
+
+    private fun ByteArray.le32(offset: Int): Int =
+        (this[offset].toInt() and 0xff) or
+            ((this[offset + 1].toInt() and 0xff) shl 8) or
+            ((this[offset + 2].toInt() and 0xff) shl 16) or
+            ((this[offset + 3].toInt() and 0xff) shl 24)
+
+    private const val COPY_BUFFER_SIZE = 64 * 1024
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/AudioDecode.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/AudioDecode.kt
@@ -15,17 +15,18 @@ import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
 import java.io.File
+import java.io.RandomAccessFile
 import java.nio.ByteOrder
 
 /**
- * Decodes a recorded audio file (the AAC/m4a produced by [RecordingController]) into the raw waveform
+ * Decodes a recorded or picked audio file into the raw waveform
  * that on-device speech recognition expects: a single channel of 32-bit float samples in `[-1, 1]` at
  * [TARGET_SAMPLE_RATE].
  *
  * On-device engines (sherpa-onnx for issue #104) consume `FloatArray` PCM directly via
  * `acceptWaveform(samples, sampleRate)` — they do not take compressed files like the cloud upload
- * endpoints do. The recorder, however, captures compressed AAC at 44.1 kHz (stereo on some devices),
- * so this is the bridge: demux → decode to PCM16 → down-mix to mono → resample to 16 kHz → to float.
+ * endpoints do. The recorder already writes 16 kHz mono PCM16 WAV, which takes the direct WAV path;
+ * picked compressed files still go through MediaExtractor/MediaCodec, then down-mix/resample to 16 kHz.
  *
  * Decoding is CPU-only and synchronous; run it off the main thread.
  */
@@ -35,6 +36,7 @@ object AudioDecode {
     const val TARGET_SAMPLE_RATE = 16_000
 
     private const val DEQUEUE_TIMEOUT_US = 10_000L
+    private const val READ_BUFFER_SIZE = 64 * 1024
 
     /**
      * Decodes [file] to mono float PCM at [TARGET_SAMPLE_RATE].
@@ -79,69 +81,137 @@ object AudioDecode {
      * channel counts / sample rates / 16-bit (and 8-bit) PCM, down-mixing and resampling as needed.
      */
     private fun decodeWavOrNull(file: File): FloatArray? {
-        val bytes = file.readBytes()
-        if (bytes.size < 44) return null
-        fun tag(off: Int) = String(bytes, off, 4, Charsets.US_ASCII)
-        if (tag(0) != "RIFF" || tag(8) != "WAVE") return null
-        fun le16(off: Int) = (bytes[off].toInt() and 0xff) or ((bytes[off + 1].toInt() and 0xff) shl 8)
-        fun le32(off: Int) = (bytes[off].toInt() and 0xff) or ((bytes[off + 1].toInt() and 0xff) shl 8) or
-            ((bytes[off + 2].toInt() and 0xff) shl 16) or ((bytes[off + 3].toInt() and 0xff) shl 24)
+        return try {
+            RandomAccessFile(file, "r").use { input ->
+                val wav = parseWav(input) ?: return null
+                if (wav.audioFormat != 1 || (wav.bitsPerSample != 16 && wav.bitsPerSample != 8)) {
+                    return null
+                }
+                val bytesPerSample = wav.bitsPerSample / 8
+                val bytesPerFrame = bytesPerSample * wav.channels
+                if (bytesPerFrame <= 0) return null
+                val framesLong = wav.dataLength / bytesPerFrame
+                if (framesLong > Int.MAX_VALUE) return null
+                val frames = framesLong.toInt()
+                val mono = FloatArray(frames)
+                input.seek(wav.dataOffset)
+                when (wav.bitsPerSample) {
+                    16 -> readPcm16Mono(input, wav.channels, frames, mono)
+                    else -> readPcm8Mono(input, wav.channels, frames, mono)
+                }
+                if (wav.sampleRate == TARGET_SAMPLE_RATE) mono
+                else resampleLinear(mono, wav.sampleRate, TARGET_SAMPLE_RATE)
+            }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private class WavInfo(
+        val audioFormat: Int,
+        val channels: Int,
+        val sampleRate: Int,
+        val bitsPerSample: Int,
+        val dataOffset: Long,
+        val dataLength: Long,
+    )
+
+    private fun parseWav(input: RandomAccessFile): WavInfo? {
+        if (input.length() < 44) return null
+        val header = ByteArray(12)
+        input.readFully(header)
+        if (!header.hasTag(0, "RIFF") || !header.hasTag(8, "WAVE")) return null
 
         var audioFormat = 1
         var channels = 1
         var sampleRate = TARGET_SAMPLE_RATE
-        var bits = 16
-        var dataOff = -1
-        var dataLen = 0
-        var p = 12 // after "RIFF"<size>"WAVE"
-        while (p + 8 <= bytes.size) {
-            val id = tag(p)
-            val size = le32(p + 4)
-            val body = p + 8
-            when (id) {
-                "fmt " -> {
-                    audioFormat = le16(body)
-                    channels = le16(body + 2).coerceAtLeast(1)
-                    sampleRate = le32(body + 4).takeIf { it > 0 } ?: TARGET_SAMPLE_RATE
-                    bits = le16(body + 14)
-                }
-                "data" -> { dataOff = body; dataLen = size.coerceAtMost(bytes.size - body) }
-            }
-            if (dataOff >= 0 && id == "data") break
-            p = body + size + (size and 1) // chunks are word-aligned
-        }
-        if (dataOff < 0 || dataLen <= 0) return null
-        if (audioFormat != 1 || (bits != 16 && bits != 8)) return null // only PCM 8/16-bit supported here
-
-        val mono: FloatArray = when (bits) {
-            16 -> {
-                val frames = dataLen / (2 * channels)
-                FloatArray(frames).also { arr ->
-                    var i = dataOff
-                    for (f in 0 until frames) {
-                        var sum = 0
-                        repeat(channels) {
-                            val s = (bytes[i].toInt() and 0xff) or (bytes[i + 1].toInt() shl 8)
-                            sum += s; i += 2
-                        }
-                        arr[f] = (sum / channels) / 32768.0f
+        var bitsPerSample = 16
+        var hasFormat = false
+        val chunkHeader = ByteArray(8)
+        while (input.filePointer + chunkHeader.size <= input.length()) {
+            input.readFully(chunkHeader)
+            val size = chunkHeader.le32(4).toLong() and 0xffff_ffffL
+            val body = input.filePointer
+            when {
+                chunkHeader.hasTag(0, "fmt ") -> {
+                    if (size >= 16L && body + 16L <= input.length()) {
+                        val bytes = ByteArray(16)
+                        input.readFully(bytes)
+                        audioFormat = bytes.le16(0)
+                        channels = bytes.le16(2).coerceAtLeast(1)
+                        sampleRate = bytes.le32(4).takeIf { it > 0 } ?: TARGET_SAMPLE_RATE
+                        bitsPerSample = bytes.le16(14)
+                        hasFormat = true
                     }
                 }
-            }
-            else -> { // 8-bit PCM is unsigned (0..255, midpoint 128)
-                val frames = dataLen / channels
-                FloatArray(frames).also { arr ->
-                    var i = dataOff
-                    for (f in 0 until frames) {
-                        var sum = 0
-                        repeat(channels) { sum += (bytes[i].toInt() and 0xff) - 128; i += 1 }
-                        arr[f] = (sum / channels) / 128.0f
-                    }
+                chunkHeader.hasTag(0, "data") -> {
+                    if (!hasFormat) return null
+                    val len = size.coerceAtMost(input.length() - body)
+                    if (len <= 0L) return null
+                    return WavInfo(audioFormat, channels, sampleRate, bitsPerSample, body, len)
                 }
             }
+            val next = (body + size + (size and 1L)).coerceAtMost(input.length())
+            input.seek(next)
         }
-        return if (sampleRate == TARGET_SAMPLE_RATE) mono else resampleLinear(mono, sampleRate, TARGET_SAMPLE_RATE)
+        return null
     }
+
+    private fun readPcm16Mono(input: RandomAccessFile, channels: Int, frames: Int, out: FloatArray) {
+        val bytesPerFrame = 2 * channels
+        val framesPerChunk = maxOf(1, READ_BUFFER_SIZE / bytesPerFrame)
+        val chunk = ByteArray(framesPerChunk * bytesPerFrame)
+        var frame = 0
+        while (frame < frames) {
+            val count = minOf(framesPerChunk, frames - frame)
+            input.readFully(chunk, 0, count * bytesPerFrame)
+            var i = 0
+            repeat(count) {
+                var sum = 0
+                repeat(channels) {
+                    val sample = (chunk[i].toInt() and 0xff) or (chunk[i + 1].toInt() shl 8)
+                    sum += sample
+                    i += 2
+                }
+                out[frame++] = (sum / channels) / 32768.0f
+            }
+        }
+    }
+
+    private fun readPcm8Mono(input: RandomAccessFile, channels: Int, frames: Int, out: FloatArray) {
+        val bytesPerFrame = channels
+        val framesPerChunk = maxOf(1, READ_BUFFER_SIZE / bytesPerFrame)
+        val chunk = ByteArray(framesPerChunk * bytesPerFrame)
+        var frame = 0
+        while (frame < frames) {
+            val count = minOf(framesPerChunk, frames - frame)
+            input.readFully(chunk, 0, count * bytesPerFrame)
+            var i = 0
+            repeat(count) {
+                var sum = 0
+                repeat(channels) {
+                    sum += (chunk[i].toInt() and 0xff) - 128
+                    i += 1
+                }
+                out[frame++] = (sum / channels) / 128.0f
+            }
+        }
+    }
+
+    private fun ByteArray.hasTag(offset: Int, tag: String): Boolean =
+        this[offset] == tag[0].code.toByte() &&
+            this[offset + 1] == tag[1].code.toByte() &&
+            this[offset + 2] == tag[2].code.toByte() &&
+            this[offset + 3] == tag[3].code.toByte()
+
+    private fun ByteArray.le16(offset: Int): Int =
+        (this[offset].toInt() and 0xff) or ((this[offset + 1].toInt() and 0xff) shl 8)
+
+    private fun ByteArray.le32(offset: Int): Int =
+        (this[offset].toInt() and 0xff) or
+            ((this[offset + 1].toInt() and 0xff) shl 8) or
+            ((this[offset + 2].toInt() and 0xff) shl 16) or
+            ((this[offset + 3].toInt() and 0xff) shl 24)
 
     private class MonoPcm(val samples: FloatArray, val sampleRate: Int)
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/Pcm16Resampler.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/Pcm16Resampler.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.dictate.audio
+
+/** Linear mono PCM16 resampling for realtime transcription provider sample-rate conversion. */
+object Pcm16Resampler {
+
+    fun resample(pcm: ByteArray, len: Int, srcRate: Int, dstRate: Int): ByteArray {
+        require(len in 0..pcm.size) { "len must be within pcm bounds" }
+        require(srcRate > 0 && dstRate > 0) { "sample rates must be positive" }
+        if (srcRate == dstRate) return if (len == pcm.size) pcm else pcm.copyOfRange(0, len)
+        if (srcRate == 16_000 && dstRate == 24_000) return resample16kTo24k(pcm, len)
+        return resampleLinear(pcm, len, srcRate, dstRate)
+    }
+
+    private fun resample16kTo24k(pcm: ByteArray, len: Int): ByteArray {
+        val inSamples = len / 2
+        if (inSamples <= 0) return ByteArray(0)
+        val outSamples = (inSamples.toLong() * 3 / 2).toInt().coerceAtLeast(1)
+        val out = ByteArray(outSamples * 2)
+        for (outIndex in 0 until outSamples) {
+            val scaled = outIndex * 2
+            val i0 = scaled / 3
+            val rem = scaled - (i0 * 3)
+            val s0 = pcmSampleAt(pcm, i0, inSamples)
+            val s1 = pcmSampleAt(pcm, i0 + 1, inSamples)
+            val v = ((s0 * 3) + ((s1 - s0) * rem)) / 3
+            writeSample(out, outIndex, v.coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()))
+        }
+        return out
+    }
+
+    private fun resampleLinear(pcm: ByteArray, len: Int, srcRate: Int, dstRate: Int): ByteArray {
+        val inSamples = len / 2
+        if (inSamples <= 0) return ByteArray(0)
+        val outSamples = (inSamples.toLong() * dstRate / srcRate).toInt().coerceAtLeast(1)
+        val out = ByteArray(outSamples * 2)
+        for (outIndex in 0 until outSamples) {
+            val srcPos = outIndex.toDouble() * srcRate / dstRate
+            val i0 = srcPos.toInt()
+            val frac = srcPos - i0
+            val s0 = pcmSampleAt(pcm, i0, inSamples)
+            val s1 = pcmSampleAt(pcm, i0 + 1, inSamples)
+            val v = (s0 + (s1 - s0) * frac).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            writeSample(out, outIndex, v)
+        }
+        return out
+    }
+
+    private fun pcmSampleAt(pcm: ByteArray, idx: Int, count: Int): Int {
+        val i = idx.coerceIn(0, count - 1)
+        val lo = pcm[i * 2].toInt() and 0xff
+        val hi = pcm[i * 2 + 1].toInt()
+        return (hi shl 8) or lo
+    }
+
+    private fun writeSample(out: ByteArray, idx: Int, value: Int) {
+        out[idx * 2] = (value and 0xff).toByte()
+        out[idx * 2 + 1] = ((value shr 8) and 0xff).toByte()
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/RecordingController.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/RecordingController.kt
@@ -57,10 +57,11 @@ class RecordingController(private val context: Context) {
      * [audioSource] defaults to the local mic; pass [MediaRecorder.AudioSource.VOICE_COMMUNICATION]
      * when recording is routed through a Bluetooth SCO headset.
      *
-     * [pcmSink], if given, receives every captured mono 16-bit LE PCM frame (a fresh array of exactly the
-     * read length) as it arrives — used to stream audio to a realtime transcription session (issue #128)
-     * while the WAV is still written in parallel (so the batch path / fallback / resend flows are intact).
-     * Called on the capture thread; keep it non-blocking (hand the bytes to a queue/socket and return).
+     * [pcmSink], if given, receives every captured mono 16-bit LE PCM frame as it arrives — used to stream
+     * audio to a realtime transcription session (issue #128) while the WAV is still written in parallel
+     * (so the batch path / fallback / resend flows are intact). The buffer is reused after the callback
+     * returns, so consumers must synchronously copy/encode/queue the first [len] bytes if they need to keep
+     * them. Called on the capture thread; keep it non-blocking (hand the bytes to a queue/socket and return).
      */
     @SuppressLint("MissingPermission") // caller holds RECORD_AUDIO; an init failure is handled below.
     fun start(
@@ -103,8 +104,7 @@ class RecordingController(private val context: Context) {
                     runCatching { out.write(buf, 0, n) }
                     pcmBytes += n
                     updatePeak(buf, n)
-                    // Copy before handing off — buf is reused on the next read. Only when streaming.
-                    if (pcmSink != null) runCatching { pcmSink(buf.copyOf(n), n) }
+                    if (pcmSink != null) runCatching { pcmSink(buf, n) }
                 }
             }
         }.also { it.start() }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/SpeechGate.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/SpeechGate.kt
@@ -71,10 +71,17 @@ object SpeechGate {
         }.getOrNull() ?: return@withContext true
 
         try {
+            val window = FloatArray(WINDOW)
             var i = 0
             while (i < samples.size) {
                 val end = minOf(i + WINDOW, samples.size)
-                vad.acceptWaveform(samples.copyOfRange(i, end))
+                val chunk = if (end - i == WINDOW) {
+                    samples.copyInto(window, destinationOffset = 0, startIndex = i, endIndex = end)
+                    window
+                } else {
+                    samples.copyOfRange(i, end)
+                }
+                vad.acceptWaveform(chunk)
                 i = end
                 if (!vad.empty()) return@withContext true // a speech segment closed → speech present
             }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/data/prompts/PromptLibraryManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/data/prompts/PromptLibraryManager.kt
@@ -71,8 +71,7 @@ object PromptLibraryManager {
      */
     suspend fun bundled(context: Context): List<PromptLibraryEntry>? = withContext(Dispatchers.IO) {
         runCatching {
-            context.applicationContext.assets.open("prompt-library.json").use { it.readBytes() }
-                .toString(Charsets.UTF_8)
+            readBundledBody(context)
         }.mapCatching { parse(it) }.getOrNull()
     }
 
@@ -118,8 +117,7 @@ object PromptLibraryManager {
         } else null
         if (cached != null) return Result(cached, fromCache = true, error = error)
         val bundled = runCatching {
-            context.applicationContext.assets.open("prompt-library.json").use { it.readBytes() }
-                .toString(Charsets.UTF_8).let { parse(it) }
+            parse(readBundledBody(context))
         }.getOrNull()
         return if (bundled != null) {
             Result(bundled, fromCache = true, error = error)
@@ -127,6 +125,11 @@ object PromptLibraryManager {
             Result(emptyList(), fromCache = false, error = error)
         }
     }
+
+    private fun readBundledBody(context: Context): String =
+        context.applicationContext.assets.open("prompt-library.json")
+            .bufferedReader(Charsets.UTF_8)
+            .use { it.readText() }
 
     private fun parse(body: String): List<PromptLibraryEntry> {
         val doc = json.decodeFromString<PromptLibraryDocument>(body)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/data/stats/DictateStats.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/data/stats/DictateStats.kt
@@ -136,8 +136,19 @@ object DictateStats {
     }
 
     /** Whitespace-delimited word count; CJK text (no spaces) collapses to a single token, which is fine. */
-    fun wordCount(text: String): Int =
-        text.trim().split(WHITESPACE).count { it.isNotBlank() }
+    fun wordCount(text: String): Int {
+        var count = 0
+        var inWord = false
+        for (ch in text) {
+            if (ch.isWhitespace()) {
+                inWord = false
+            } else if (!inWord) {
+                count++
+                inWord = true
+            }
+        }
+        return count
+    }
 
     /**
      * Words per day for the last [DAILY_WINDOW_DAYS] days, oldest → newest and aligned to [today] so the
@@ -182,6 +193,4 @@ object DictateStats {
 
     private fun serializeDaily(map: Map<Long, Long>): String =
         map.entries.sortedBy { it.key }.joinToString(";") { "${it.key}:${it.value}" }
-
-    private val WHITESPACE = Regex("\\s+")
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/LocalTranscriptionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/LocalTranscriptionProvider.kt
@@ -133,10 +133,17 @@ class LocalTranscriptionProvider(
         )
         val parts = StringBuilder()
         try {
+            val window = FloatArray(VAD_WINDOW)
             var i = 0
             while (i < samples.size) {
                 val end = minOf(i + VAD_WINDOW, samples.size)
-                vad.acceptWaveform(samples.copyOfRange(i, end))
+                val chunk = if (end - i == VAD_WINDOW) {
+                    samples.copyInto(window, destinationOffset = 0, startIndex = i, endIndex = end)
+                    window
+                } else {
+                    samples.copyOfRange(i, end)
+                }
+                vad.acceptWaveform(chunk)
                 i = end
                 drainSegments(vad, recognizer, parts)
             }

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/AudioWavTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/AudioWavTest.kt
@@ -1,0 +1,86 @@
+package dev.patrickgold.florisboard.dictate
+
+import dev.patrickgold.florisboard.dictate.audio.AudioConcat
+import dev.patrickgold.florisboard.dictate.audio.AudioDecode
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AudioWavTest {
+
+    @Test
+    fun decodePcm16MonoWav() {
+        val dir = Files.createTempDirectory("dictate-wav-decode").toFile()
+        try {
+            val wav = File(dir, "sample.wav").also {
+                it.writeBytes(wavBytes(shortArrayOf(Short.MIN_VALUE, 0, Short.MAX_VALUE)))
+            }
+
+            val samples = AudioDecode.decodeToMono16k(wav)
+
+            assertEquals(3, samples.size)
+            assertNear(-1.0f, samples[0])
+            assertNear(0.0f, samples[1])
+            assertNear(Short.MAX_VALUE / 32768.0f, samples[2])
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun concatPcm16WavSegments() {
+        val dir = Files.createTempDirectory("dictate-wav-concat").toFile()
+        try {
+            val first = File(dir, "first.wav").also {
+                it.writeBytes(wavBytes(shortArrayOf(1_000, -1_000)))
+            }
+            val second = File(dir, "second.wav").also {
+                it.writeBytes(wavBytes(shortArrayOf(500)))
+            }
+            val output = File(dir, "merged.wav")
+
+            assertTrue(AudioConcat.concat(listOf(first, second), output))
+            val samples = AudioDecode.decodeToMono16k(output)
+
+            assertEquals(3, samples.size)
+            assertNear(1_000 / 32768.0f, samples[0])
+            assertNear(-1_000 / 32768.0f, samples[1])
+            assertNear(500 / 32768.0f, samples[2])
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun assertNear(expected: Float, actual: Float) {
+        assertTrue(abs(expected - actual) < 0.000001f, "expected=$expected actual=$actual")
+    }
+
+    private fun wavBytes(samples: ShortArray): ByteArray {
+        val dataLen = samples.size * 2
+        return ByteBuffer.allocate(WAV_HEADER_SIZE + dataLen).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put("RIFF".toByteArray(Charsets.US_ASCII))
+            putInt(36 + dataLen)
+            put("WAVE".toByteArray(Charsets.US_ASCII))
+            put("fmt ".toByteArray(Charsets.US_ASCII))
+            putInt(16)
+            putShort(1)
+            putShort(1)
+            putInt(AudioDecode.TARGET_SAMPLE_RATE)
+            putInt(AudioDecode.TARGET_SAMPLE_RATE * 2)
+            putShort(2)
+            putShort(16)
+            put("data".toByteArray(Charsets.US_ASCII))
+            putInt(dataLen)
+            samples.forEach { putShort(it) }
+        }.array()
+    }
+
+    private companion object {
+        const val WAV_HEADER_SIZE = 44
+    }
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/DictateStatsTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/DictateStatsTest.kt
@@ -1,0 +1,22 @@
+package dev.patrickgold.florisboard.dictate
+
+import dev.patrickgold.florisboard.dictate.data.stats.DictateStats
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DictateStatsTest {
+
+    @Test
+    fun wordCountHandlesWhitespaceSeparatedText() {
+        assertEquals(0, DictateStats.wordCount(""))
+        assertEquals(0, DictateStats.wordCount(" \n\t "))
+        assertEquals(1, DictateStats.wordCount("hello"))
+        assertEquals(2, DictateStats.wordCount("  hello   world  "))
+        assertEquals(3, DictateStats.wordCount("one\ntwo\tthree"))
+    }
+
+    @Test
+    fun wordCountTreatsUnspacedCjkAsOneToken() {
+        assertEquals(1, DictateStats.wordCount("你好世界"))
+    }
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/Pcm16ResamplerTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/Pcm16ResamplerTest.kt
@@ -1,0 +1,100 @@
+package dev.patrickgold.florisboard.dictate
+
+import dev.patrickgold.florisboard.dictate.audio.Pcm16Resampler
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class Pcm16ResamplerTest {
+
+    @Test
+    fun resample16kTo24kMatchesReferenceInterpolation() {
+        val pcm = deterministicPcm16(sampleCount = 513)
+
+        for (sampleCount in listOf(1, 2, 3, 7, 32, 257, 513)) {
+            val len = sampleCount * 2
+            assertPcm16Near(
+                referenceResample(pcm, len, srcRate = 16_000, dstRate = 24_000),
+                Pcm16Resampler.resample(pcm, len, srcRate = 16_000, dstRate = 24_000),
+                maxDelta = 1,
+            )
+        }
+    }
+
+    @Test
+    fun genericResamplingPathMatchesReferenceInterpolation() {
+        val pcm = deterministicPcm16(sampleCount = 257)
+
+        assertContentEquals(
+            referenceResample(pcm, len = 257 * 2, srcRate = 16_000, dstRate = 8_000),
+            Pcm16Resampler.resample(pcm, len = 257 * 2, srcRate = 16_000, dstRate = 8_000),
+        )
+    }
+
+    @Test
+    fun sameRateResamplingUsesOnlyProvidedLength() {
+        val pcm = deterministicPcm16(sampleCount = 8)
+
+        assertContentEquals(
+            pcm.copyOfRange(0, 6),
+            Pcm16Resampler.resample(pcm, len = 6, srcRate = 16_000, dstRate = 16_000),
+        )
+    }
+
+    private fun deterministicPcm16(sampleCount: Int): ByteArray {
+        val out = ByteArray(sampleCount * 2)
+        var state = 0x13579bdf
+        for (i in 0 until sampleCount) {
+            state = state * 1103515245 + 12345
+            val value = when (i % 17) {
+                0 -> Short.MIN_VALUE.toInt()
+                1 -> Short.MAX_VALUE.toInt()
+                else -> (state shr 16).toShort().toInt()
+            }
+            out[i * 2] = (value and 0xff).toByte()
+            out[i * 2 + 1] = ((value shr 8) and 0xff).toByte()
+        }
+        return out
+    }
+
+    private fun referenceResample(pcm: ByteArray, len: Int, srcRate: Int, dstRate: Int): ByteArray {
+        if (srcRate == dstRate) return if (len == pcm.size) pcm else pcm.copyOf(len)
+        val inSamples = len / 2
+        if (inSamples <= 0) return ByteArray(0)
+        val outSamples = (inSamples.toLong() * dstRate / srcRate).toInt().coerceAtLeast(1)
+        val out = ByteArray(outSamples * 2)
+        for (outIndex in 0 until outSamples) {
+            val srcPos = outIndex.toDouble() * srcRate / dstRate
+            val i0 = srcPos.toInt()
+            val frac = srcPos - i0
+            val s0 = pcmSampleAt(pcm, i0, inSamples)
+            val s1 = pcmSampleAt(pcm, i0 + 1, inSamples)
+            val v = (s0 + (s1 - s0) * frac).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            out[outIndex * 2] = (v and 0xff).toByte()
+            out[outIndex * 2 + 1] = ((v shr 8) and 0xff).toByte()
+        }
+        return out
+    }
+
+    private fun assertPcm16Near(expected: ByteArray, actual: ByteArray, maxDelta: Int) {
+        assertEquals(expected.size, actual.size)
+        var i = 0
+        while (i + 1 < expected.size) {
+            val expectedSample = pcmSampleAt(expected, i / 2, expected.size / 2)
+            val actualSample = pcmSampleAt(actual, i / 2, actual.size / 2)
+            assertTrue(
+                kotlin.math.abs(expectedSample - actualSample) <= maxDelta,
+                "sample=${i / 2} expected=$expectedSample actual=$actualSample",
+            )
+            i += 2
+        }
+    }
+
+    private fun pcmSampleAt(pcm: ByteArray, idx: Int, count: Int): Int {
+        val i = idx.coerceIn(0, count - 1)
+        val lo = pcm[i * 2].toInt() and 0xff
+        val hi = pcm[i * 2 + 1].toInt()
+        return (hi shl 8) or lo
+    }
+}

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiCompatibleClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiCompatibleClient.kt
@@ -10,6 +10,8 @@
 
 package dev.patrickgold.florisboard.dictate.provider
 
+import android.util.Base64
+import android.util.Base64OutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -27,6 +29,7 @@ import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
 import java.io.IOException
+import java.io.OutputStream
 import java.net.Proxy
 import java.security.KeyStore
 import java.time.Duration
@@ -151,7 +154,7 @@ class OpenAiCompatibleClient(
         onRetry: (attempt: Int) -> Unit,
     ): TranscriptionResult {
         val base64 = withContext(Dispatchers.IO) {
-            android.util.Base64.encodeToString(request.audioFile.readBytes(), android.util.Base64.NO_WRAP)
+            base64EncodeFile(request.audioFile)
         }
         val lang = request.language?.takeIf { it.isNotEmpty() && it != "detect" }
         val dto = TranscriptionJsonRequestDto(
@@ -182,7 +185,7 @@ class OpenAiCompatibleClient(
         onRetry: (attempt: Int) -> Unit,
     ): TranscriptionResult {
         val base64 = withContext(Dispatchers.IO) {
-            android.util.Base64.encodeToString(request.audioFile.readBytes(), android.util.Base64.NO_WRAP)
+            base64EncodeFile(request.audioFile)
         }
         val extra = request.prompt?.trim()?.takeIf { it.isNotEmpty() }
         val instruction = buildString {
@@ -492,7 +495,7 @@ class OpenAiCompatibleClient(
         onRetry: (attempt: Int) -> Unit,
     ): TranscriptionResult {
         val base64 = withContext(Dispatchers.IO) {
-            android.util.Base64.encodeToString(request.audioFile.readBytes(), android.util.Base64.NO_WRAP)
+            base64EncodeFile(request.audioFile)
         }
         val mimeType = guessAudioMediaType(request.audioFile).toString().substringBefore(";").trim()
         val dto = GeminiGenerateRequestDto(
@@ -770,6 +773,41 @@ class OpenAiCompatibleClient(
         "oga", "ogg" -> "ogg"
         "wav", "flac", "webm" -> ext
         else -> ext
+    }
+
+    private fun base64EncodeFile(file: File): String {
+        val out = Base64StringOutput(base64Capacity(file.length()))
+        file.inputStream().use { input ->
+            Base64OutputStream(out, Base64.NO_WRAP).use { base64 ->
+                input.copyTo(base64)
+            }
+        }
+        return out.toString()
+    }
+
+    private fun base64Capacity(length: Long): Int {
+        if (length <= 0L) return 16
+        if (length >= (Int.MAX_VALUE.toLong() / 4L) * 3L) return Int.MAX_VALUE
+        return (((length + 2L) / 3L) * 4L).toInt()
+    }
+
+    private class Base64StringOutput(initialCapacity: Int) : OutputStream() {
+        private val builder = StringBuilder(initialCapacity)
+
+        override fun write(b: Int) {
+            builder.append((b and 0xff).toChar())
+        }
+
+        override fun write(buffer: ByteArray, offset: Int, length: Int) {
+            var i = offset
+            val end = offset + length
+            while (i < end) {
+                builder.append((buffer[i].toInt() and 0xff).toChar())
+                i++
+            }
+        }
+
+        override fun toString(): String = builder.toString()
     }
 
     @Serializable

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderConfig.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderConfig.kt
@@ -143,6 +143,7 @@ data class ProxyConfig(
     companion object {
         private val REGEX =
             Regex("^(?:(socks5|http)://)?(?:(\\w+):(\\w+)@)?([\\w.-]+):(\\d+)$")
+        private val IPV4_REGEX = Regex("\\d+\\.\\d+\\.\\d+\\.\\d+")
 
         /**
          * Builds a config from the individual settings fields, or `null` when the proxy is disabled or
@@ -174,7 +175,7 @@ data class ProxyConfig(
             if (spec.isNullOrEmpty()) return false
             val match = REGEX.matchEntire(spec) ?: return false
             val host = match.groupValues[4]
-            if (host.matches(Regex("\\d+\\.\\d+\\.\\d+\\.\\d+"))) {
+            if (host.matches(IPV4_REGEX)) {
                 return host.split(".").all { part -> part.toIntOrNull()?.let { it in 0..255 } == true }
             }
             return true

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
@@ -179,8 +179,7 @@ private class OpenAiRealtimeSession(
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
         val socket = ws ?: return
-        val bytes = if (len == pcm16.size) pcm16 else pcm16.copyOf(len)
-        val b64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+        val b64 = Base64.encodeToString(pcm16, 0, len, Base64.NO_WRAP)
         val msg = buildJsonObject {
             put("type", "input_audio_buffer.append")
             put("audio", b64)
@@ -443,10 +442,9 @@ private class ElevenLabsRealtimeSession(
     }
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
-        val bytes = if (len == pcm16.size) pcm16 else pcm16.copyOf(len)
         val msg = buildJsonObject {
             put("message_type", "input_audio_chunk")
-            put("audio_base_64", Base64.encodeToString(bytes, Base64.NO_WRAP))
+            put("audio_base_64", Base64.encodeToString(pcm16, 0, len, Base64.NO_WRAP))
             put("commit", false)
             put("sample_rate", 16_000)
         }.toString()
@@ -554,11 +552,10 @@ private class GeminiRealtimeSession(
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
         if (!started) return   // wait for setupComplete before streaming audio (Gemini Live requirement)
-        val bytes = if (len == pcm16.size) pcm16 else pcm16.copyOf(len)
         val msg = buildJsonObject {
             putJsonObject("realtimeInput") {
                 putJsonObject("audio") {
-                    put("data", Base64.encodeToString(bytes, Base64.NO_WRAP))
+                    put("data", Base64.encodeToString(pcm16, 0, len, Base64.NO_WRAP))
                     put("mimeType", "audio/pcm;rate=16000")
                 }
             }

--- a/wear/src/main/kotlin/net/devemperor/dictate/wear/audio/WearAudioRecorder.kt
+++ b/wear/src/main/kotlin/net/devemperor/dictate/wear/audio/WearAudioRecorder.kt
@@ -11,10 +11,10 @@ import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
-import java.io.ByteArrayOutputStream
-import java.io.DataOutputStream
 import java.io.File
-import java.io.FileOutputStream
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 /**
  * Minimal microphone recorder for the watch (#106). Captures 16 kHz mono 16-bit PCM via [AudioRecord]
@@ -28,11 +28,13 @@ class WearAudioRecorder(private val context: Context) {
 
     private var record: AudioRecord? = null
     private var thread: Thread? = null
+    private var raf: RandomAccessFile? = null
     @Volatile private var recording = false
     @Volatile private var paused = false
-    private val pcm = ByteArrayOutputStream()
+    @Volatile private var pcmBytes = 0L
     /** Peak |sample| (0..32767) seen since the last [maxAmplitude] call; drives the live waveform. */
     @Volatile private var peak = 0
+    private var outputFile: File? = null
 
     val isRecording: Boolean get() = recording
 
@@ -45,6 +47,7 @@ class WearAudioRecorder(private val context: Context) {
 
     @SuppressLint("MissingPermission") // caller guarantees RECORD_AUDIO; init failure is handled below.
     fun start() {
+        if (recording) return
         val minBuf = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL, ENCODING)
         require(minBuf > 0) { "AudioRecord unavailable on this device" }
         val bufferSize = minBuf * 2
@@ -55,9 +58,24 @@ class WearAudioRecorder(private val context: Context) {
             ENCODING,
             bufferSize,
         )
-        check(recorder.state == AudioRecord.STATE_INITIALIZED) { "AudioRecord failed to initialize" }
-        pcm.reset()
+        if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+            runCatching { recorder.release() }
+            error("AudioRecord failed to initialize")
+        }
+        val file = File(context.cacheDir, "wear_dictation_${System.currentTimeMillis()}.wav")
+        val out = try {
+            RandomAccessFile(file, "rw").apply {
+                setLength(0)
+                write(ByteArray(WAV_HEADER_SIZE))
+            }
+        } catch (t: Throwable) {
+            runCatching { recorder.release() }
+            throw t
+        }
         peak = 0
+        pcmBytes = 0L
+        outputFile = file
+        raf = out
         record = recorder
         recording = true
         paused = false
@@ -69,7 +87,8 @@ class WearAudioRecorder(private val context: Context) {
                 // Keep draining the mic while paused (so the buffer never overflows) but drop the audio,
                 // so paused time contributes no samples — matching the phone's pause behavior.
                 if (read > 0 && !paused) {
-                    pcm.write(buf, 0, read)
+                    runCatching { out.write(buf, 0, read) }
+                    pcmBytes += read
                     updatePeak(buf, read)
                 }
             }
@@ -102,10 +121,22 @@ class WearAudioRecorder(private val context: Context) {
         record?.run { stop(); release() }
         record = null
 
-        val pcmBytes = pcm.toByteArray()
-        val out = File(context.cacheDir, "wear_dictation_${pcmBytes.size}.wav")
-        writeWav(out, pcmBytes)
-        return out
+        val out = checkNotNull(raf) { "Recorder was not started" }
+        raf = null
+        val file = checkNotNull(outputFile) { "Recorder output file missing" }
+        return try {
+            out.seek(0)
+            out.write(wavHeader(pcmBytes))
+            out.close()
+            file
+        } catch (t: Throwable) {
+            runCatching { out.close() }
+            file.delete()
+            throw t
+        } finally {
+            outputFile = null
+            pcmBytes = 0L
+        }
     }
 
     fun cancel() {
@@ -114,40 +145,30 @@ class WearAudioRecorder(private val context: Context) {
         thread = null
         record?.run { stop(); release() }
         record = null
-        pcm.reset()
+        runCatching { raf?.close() }
+        raf = null
+        outputFile?.delete()
+        outputFile = null
+        pcmBytes = 0L
     }
 
-    private fun writeWav(file: File, pcmData: ByteArray) {
-        val totalDataLen = pcmData.size + 36
+    private fun wavHeader(dataLen: Long): ByteArray {
         val byteRate = SAMPLE_RATE * CHANNELS * BITS_PER_SAMPLE / 8
-        DataOutputStream(FileOutputStream(file)).use { out ->
-            out.writeBytes("RIFF")
-            out.writeIntLe(totalDataLen)
-            out.writeBytes("WAVE")
-            out.writeBytes("fmt ")
-            out.writeIntLe(16)                 // PCM subchunk size
-            out.writeShortLe(1)                // audio format = PCM
-            out.writeShortLe(CHANNELS)
-            out.writeIntLe(SAMPLE_RATE)
-            out.writeIntLe(byteRate)
-            out.writeShortLe(CHANNELS * BITS_PER_SAMPLE / 8) // block align
-            out.writeShortLe(BITS_PER_SAMPLE)
-            out.writeBytes("data")
-            out.writeIntLe(pcmData.size)
-            out.write(pcmData)
-        }
-    }
-
-    private fun DataOutputStream.writeIntLe(value: Int) {
-        write(value and 0xff)
-        write((value shr 8) and 0xff)
-        write((value shr 16) and 0xff)
-        write((value shr 24) and 0xff)
-    }
-
-    private fun DataOutputStream.writeShortLe(value: Int) {
-        write(value and 0xff)
-        write((value shr 8) and 0xff)
+        return ByteBuffer.allocate(WAV_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put("RIFF".toByteArray(Charsets.US_ASCII))
+            putInt((36 + dataLen).toInt())
+            put("WAVE".toByteArray(Charsets.US_ASCII))
+            put("fmt ".toByteArray(Charsets.US_ASCII))
+            putInt(16)                 // PCM subchunk size
+            putShort(1)                // audio format = PCM
+            putShort(CHANNELS.toShort())
+            putInt(SAMPLE_RATE)
+            putInt(byteRate)
+            putShort((CHANNELS * BITS_PER_SAMPLE / 8).toShort()) // block align
+            putShort(BITS_PER_SAMPLE.toShort())
+            put("data".toByteArray(Charsets.US_ASCII))
+            putInt(dataLen.toInt())
+        }.array()
     }
 
     private companion object {
@@ -156,5 +177,6 @@ class WearAudioRecorder(private val context: Context) {
         const val ENCODING = AudioFormat.ENCODING_PCM_16BIT
         const val CHANNELS = 1
         const val BITS_PER_SAMPLE = 16
+        const val WAV_HEADER_SIZE = 44
     }
 }


### PR DESCRIPTION
## Summary

This PR improves Dictate's audio pipeline by removing avoidable heap copies, reducing short-lived allocations, and making the realtime microphone-to-provider path cheaper. The main theme is simple: Dictate already records audio in the format most downstream code wants, so the app should stream, encode, and resample from bounded buffers instead of repeatedly materializing full or trimmed arrays.

The work covers both the batch path and the realtime path:

- WAV concatenation for continued/interrupted recordings
- WAV decoding before local speech detection and on-device transcription
- Silero VAD window handling
- Wear OS recording
- realtime PCM capture, JSON/base64 sending, and 16 kHz to 24 kHz resampling
- small repeated validation overhead in provider settings

## Experiment-Driven Realtime Goals

After the first audio-pipeline pass, I ran an additional focused experiment loop on the realtime capture/send/resample hot path. The SMART goals were mechanical and measurable:

1. Reduce realtime capture-copy sites from 1 to 0.
2. Reduce JSON realtime trim-copy sites from 3 to 0.
3. Reduce same-rate realtime resampling/copy sites from 1 to 0.
4. Keep a dedicated 16 kHz to 24 kHz PCM resampling path at least 25% faster than the generic interpolation benchmark.

The baseline realtime hotspot metric was 5. The final metric is 0.

| Metric | Baseline | Final |
| --- | ---: | ---: |
| `copy_sites_total` | 5 | 0 |
| `capture_copy_sites` | 1 | 0 |
| `json_trim_copy_sites` | 3 | 0 |
| `same_rate_realtime_copy_sites` | 1 | 0 |
| 16 kHz -> 24 kHz fast-path benchmark gain | 26.767% estimated | 35.507% final run |

The final local verification JSON was:

```json
{"realtime_hotspot_score":0,"copy_sites_total":0,"capture_copy_sites":0,"json_trim_copy_sites":0,"same_rate_realtime_copy_sites":0,"resampler_fast_path_sites":2,"resample_generic_ns_per_run":1871374,"resample_fast_ns_per_run":1206899.25,"resample_fast_gain_pct":35.507}
```

No live provider API calls were needed for these tests; the changes are verified locally and deterministically.

## What Changed

### Stream WAV concatenation instead of loading whole segments

`AudioConcat` previously parsed every segment by calling `File.readBytes()`, then wrote the PCM payload from the resulting in-memory array. Continued recordings therefore allocated one full `ByteArray` per segment before producing the merged file.

This PR changes `AudioConcat` to parse WAV headers from `RandomAccessFile`, seek directly to the `data` chunk, copy PCM data in 64 KiB chunks, and write the final WAV header from the actual copied byte count. The merge now uses bounded working memory instead of heap proportional to the full recording size.

### Decode PCM WAV files directly from disk

`AudioDecode.decodeWavOrNull()` previously used `file.readBytes()` for WAV inputs. That was especially wasteful for Dictate's own recorder output, because the recorder already writes 16 kHz mono PCM16 WAV, which is the ideal input for the local speech paths.

The direct WAV path now parses RIFF/WAVE chunks from `RandomAccessFile`, validates PCM 8-bit/16-bit formats as before, streams PCM frames through a reusable 64 KiB buffer, and writes decoded mono samples directly into the target `FloatArray`. Picked or compressed files still use the existing `MediaExtractor`/`MediaCodec` path.

### Reuse VAD window buffers

The silence gate and long-audio local transcription segmentation feed Silero VAD in fixed 512-sample windows. Before this PR, each full window used `copyOfRange()`, allocating a new `FloatArray` for every window.

This PR reuses one 512-sample buffer for full windows and only allocates for the final partial tail window. For long recordings, that removes thousands of tiny short-lived allocations from the VAD path.

### Stream Wear OS recordings directly to file

`WearAudioRecorder` previously buffered the whole PCM recording in a `ByteArrayOutputStream` and only wrote the WAV file on `stop()`. That kept the entire recording in heap memory and copied it again via `toByteArray()`.

The watch recorder now mirrors the phone-side approach: create the WAV file at recording start, write a placeholder header, stream captured PCM directly into a `RandomAccessFile`, patch the header on stop, and clean up the partial file on cancel/failure. This is a better fit for Wear OS memory and CPU budgets.

### Avoid capture-thread PCM copies for realtime streaming

`RecordingController` copied each microphone read with `buf.copyOf(n)` before handing it to the realtime PCM sink. The sink is called synchronously on the capture thread, and every realtime session either encodes immediately or creates an Okio `ByteString` immediately, so the extra defensive copy was avoidable.

The sink contract now documents that the buffer is reused after the callback returns. The capture thread passes the reused buffer plus `len`, eliminating one allocation and copy per audio read while preserving the WAV fallback recording in parallel.

### Avoid Base64 trim copies in JSON realtime providers

OpenAI, ElevenLabs, and Gemini realtime sessions used this pattern before base64 encoding:

```kotlin
val bytes = if (len == pcm16.size) pcm16 else pcm16.copyOf(len)
Base64.encodeToString(bytes, Base64.NO_WRAP)
```

Android's `Base64.encodeToString` already supports offset and length, so the PR now encodes exactly `pcm16[0, len)` directly. This removes three send-path allocation sites without changing any JSON wire format.

### Add a realtime PCM resampler fast path

OpenAI realtime expects 24 kHz PCM, while the microphone recorder captures 16 kHz PCM. The previous resampler was embedded inside `DictateController` and used a generic floating-point interpolation loop for every provider rate. It also copied audio even when the provider already wanted the native 16 kHz rate.

This PR extracts `Pcm16Resampler`, bypasses resampling entirely for same-rate providers, and adds a dedicated 16 kHz to 24 kHz 3:2 fast path. The fast path avoids per-sample floating-point position calculation and is covered by focused unit tests. The test allows a 1-LSB PCM tolerance against the previous floating-point interpolation because integer-rational interpolation and double rounding can differ by one sample unit while remaining audibly equivalent.

### Cache the IPv4 validation regex

`ProviderConfig.ProxyConfig.isValid()` now reuses a precompiled IPv4 regex instead of constructing one during each proxy validation call.

### Add focused tests

`AudioWavTest` covers direct PCM WAV decoding and WAV concatenation. `Pcm16ResamplerTest` covers the new 16 kHz to 24 kHz fast path, the generic fallback path, and same-rate length handling.

## Why This Adds Value

Dictate is an interactive keyboard. The most important performance window is the short period while the user is speaking and immediately after they stop, because any extra CPU work or GC pause directly affects perceived responsiveness.

The previous implementation did extra heap work in exactly those paths:

- continued recordings loaded full WAV segments before merging
- local speech detection loaded complete WAV files before decoding
- VAD segmentation allocated many tiny arrays
- Wear OS kept whole recordings in memory before writing the final WAV
- realtime recording copied every microphone buffer before sending it
- JSON realtime providers copied every partial buffer before base64 encoding
- 16 kHz realtime providers still passed through a same-rate resampling function that could trim-copy buffers
- OpenAI's 24 kHz realtime path used a generic floating-point resampler despite always needing a fixed 3:2 conversion from Dictate's 16 kHz recorder

None of those copies improves transcription quality, provider compatibility, or user-visible behavior. They are implementation overhead. Removing them makes the app more predictable under load, especially on lower-memory phones and watches.

Concrete benefits:

- Lower peak memory for long dictations and continued recordings.
- Less GC pressure in realtime streaming, where small repeated allocations are especially harmful.
- Faster stop-to-transcribe handoff for WAV-based local and fallback paths.
- Better Wear OS behavior by avoiding full-recording heap buffers.
- Cheaper OpenAI realtime streaming through a specialized 16 kHz to 24 kHz conversion path.
- No provider wire-format change and no UI behavior change.

This is intentionally not a broad refactor. It keeps existing formats, APIs, fallback behavior, and provider protocols intact while making the existing implementation more streaming-oriented.

## Behavioral Compatibility

The PR preserves the current behavior:

- Dictate still records WAV files at 16 kHz mono PCM16.
- Picked/compressed files still use `MediaExtractor`/`MediaCodec`.
- WAV chunk parsing still supports PCM 8-bit and 16-bit inputs.
- Silence-gate failure behavior still fails open.
- Local transcription still receives 16 kHz mono float samples.
- Wear OS still returns a `.wav` file from `stop()`.
- Realtime providers receive the same audio format and wire messages as before.
- Same-rate realtime providers now receive the original PCM buffer plus `len`, matching the `RealtimeSession.sendAudio` contract.

## Validation

I validated the final branch with:

- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File C:\Users\Alexander.Immler\Documents\Dictate\autoresearch-results\verify_realtime_perf.ps1`
- `./gradlew.bat :wear:compileDebugKotlin :app:testDebugUnitTest`
- `./gradlew.bat :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.dictate.Pcm16ResamplerTest"`

Earlier validation during the first pass also included:

- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :wear:compileDebugKotlin`
- `./gradlew.bat :app:testDebugUnitTest`

Notes:

- The build emits existing Kotlin/resource/deprecation warnings unrelated to this PR.
- The app module requires the vendored sherpa-onnx artifacts for `verifySherpaOnnxLibs`; those were present locally for validation and remain ignored by git.

## Risk and Mitigation

The main risk is in audio format handling and resampling edge cases. The PR mitigates that by keeping compressed audio on the old codec path, adding focused JVM tests for direct WAV decode/concat, and adding focused resampler tests for the new fast path and fallback path.

The realtime zero-copy capture change relies on the documented synchronous lifetime of the sink buffer. Current senders either encode immediately or create an immutable `ByteString` immediately, so they do not retain the mutable capture buffer beyond the callback.
## Additional AutoResearch Pass: Other Performance Improvements

After the realtime-focused pass, I ran a second foreground AutoResearch loop against other performance-sensitive code paths. The mechanical goal was to remove three remaining categories of avoidable allocation-heavy work outside the realtime sender:

| Metric | Baseline | Final |
| --- | ---: | ---: |
| `other_perf_hotspot_score` | 6 | 0 |
| `batch_audio_readbytes_sites` | 3 | 0 |
| `prompt_asset_readbytes_sites` | 2 | 0 |
| `stats_word_split_sites` | 1 | 0 |
| manual word-count benchmark gain | 82.488% estimated | 80.988% final run |

Final verification output:

```json
{"other_perf_hotspot_score":0,"batch_audio_readbytes_sites":0,"prompt_asset_readbytes_sites":0,"stats_word_split_sites":0,"word_count_regex_ns_per_run":43638.329,"word_count_manual_ns_per_run":8296.386,"word_count_manual_gain_pct":80.988}
```

### Batch JSON audio encoding

OpenRouter JSON transcription, single-call chat-audio transcription, and Gemini native `generateContent` transcription all need base64 audio in JSON. Previously each path called `audioFile.readBytes()` before encoding, which meant large recordings were fully materialized as raw bytes before producing the base64 payload.

The PR now streams the file through `Base64OutputStream` into an ASCII string output. The JSON payload still contains the same base64 data, but the client no longer needs a separate full raw-audio `ByteArray` allocation before building it.

### Bundled prompt-library fallback reads

The bundled `prompt-library.json` fallback previously used `readBytes()` and then converted the byte array to text in two places. Those paths now share a `bufferedReader(Charsets.UTF_8).readText()` helper, removing the byte-array intermediate while preserving the same parsed JSON behavior.

### Dictation statistics word counting

`DictateStats.wordCount()` previously used `text.trim().split(Regex("\\s+")).count { ... }`, which allocates a list of tokens for every successful dictation. It now uses a linear whitespace scanner that counts word starts without allocating token substrings/lists. Focused tests cover blank input, repeated whitespace, newline/tab separators, and unspaced CJK text.

Additional validation for this pass:

- `powershell -NoProfile -ExecutionPolicy Bypass -File C:\Users\Alexander.Immler\Documents\Dictate\autoresearch-results\verify_other_perf.ps1`
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.dictate.DictateStatsTest"`
- `./gradlew.bat :wear:compileDebugKotlin :app:testDebugUnitTest`
- `git diff --check`
