### PR TITLE
feat: add VOICE_COMMUNICATION audio source option

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/DictateAudioSource.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/audio/DictateAudioSource.kt
@@ -28,12 +28,14 @@ import android.media.MediaRecorder
  */
 enum class DictateAudioSource {
     DEFAULT,
+    VOICE_COMMUNICATION,
     VOICE_RECOGNITION,
     UNPROCESSED;
 
     /** Maps to a [MediaRecorder.AudioSource], degrading [UNPROCESSED] → [VOICE_RECOGNITION] when unsupported. */
     fun resolve(context: Context): Int = when (this) {
         DEFAULT -> MediaRecorder.AudioSource.MIC
+        VOICE_COMMUNICATION -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
         VOICE_RECOGNITION -> MediaRecorder.AudioSource.VOICE_RECOGNITION
         UNPROCESSED -> {
             val am = context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager


### PR DESCRIPTION
## Что добавлено

Добавлен новый режим `VOICE_COMMUNICATION` в `DictateAudioSource` — позволяет использовать
`MediaRecorder.AudioSource.VOICE_COMMUNICATION` (приоритет 7) для захвата аудио.

## Зачем это нужно

Сейчас Dictate использует `MIC` или `VOICE_RECOGNITION` — оба с низким приоритетом.
Когда другое приложение (диктофон, камера) держит микрофон через `CAMCORDER` (приоритет 5),
Dictate глушится — голосовой ввод перестаёт работать.

`VOICE_COMMUNICATION` имеет **самый высокий приоритет (7)** среди аудиоисточников,
поэтому Dictate не будет заглушаться при параллельной записи на диктофон или камеру.

## Что изменилось

В одном файле `DictateAudioSource.kt` добавлено 2 строки:

```kotlin
VOICE_COMMUNICATION,  // новый enum
VOICE_COMMUNICATION -> MediaRecorder.AudioSource.VOICE_COMMUNICATION  // resolve()
```

## Примечание

`VOICE_COMMUNICATION` уже упоминался в javadoc класса (строка 27) как используемый для
Bluetooth-SCO. Этот PR просто делает его доступным для выбора пользователем.