### PR TITLE
Fix NullPointerException in LatinLanguageProvider init block

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -79,19 +79,6 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
 
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    init {
-        // When a dictionary finishes downloading, drop the resolved-language cache so the active subtype
-        // starts using it immediately (issue #127).
-        ioScope.launch {
-            GlideDictionaryManager.installedVersion.collect {
-                resolvedDictLang.clear()
-                rankedWordsByLang.withLock { it.clear() }
-                lowerIndexByLang.withLock { it.clear() }
-                bigramsByLang.withLock { it.clear() }
-            }
-        }
-    }
-
     // Word→frequency dictionaries cached per language (issue #127, glide typing phase 2). Each bundled
     // ime/dict/<lang>.json maps a word to a frequency in [128,255]; languages without a bundled file fall
     // back to English.
@@ -227,6 +214,19 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
     )
 
     private val lowerIndexByLang = guardedByLock { mutableMapOf<String, LowerIndex>() }
+
+    init {
+        // When a dictionary finishes downloading, drop the resolved-language cache so the active subtype
+        // starts using it immediately (issue #127).
+        ioScope.launch {
+            GlideDictionaryManager.installedVersion.collect {
+                resolvedDictLang.clear()
+                rankedWordsByLang.withLock { it.clear() }
+                lowerIndexByLang.withLock { it.clear() }
+                bigramsByLang.withLock { it.clear() }
+            }
+        }
+    }
 
     private suspend fun lowerIndexFor(subtype: Subtype): LowerIndex {
         val lang = dictLangFor(subtype)


### PR DESCRIPTION
## Bug
`java.lang.NullPointerException: Attempt to invoke virtual method 'void java.util.concurrent.ConcurrentHashMap.clear()' on a null object reference` at `LatinLanguageProvider.kt:87`

## Root Cause
The `init{}` block was declared at line 82, but accesses four properties declared AFTER it:
- `resolvedDictLang` (line 117) ← crash site
- `rankedWordsByLang` (line 103)
- `lowerIndexByLang` (line 229)
- `bigramsByLang` (line 163)

In Kotlin, property initializers and `init` blocks execute in declaration order. The `init` block launches a coroutine on `Dispatchers.IO` which collects from a `StateFlow` — and `StateFlow.collect()` emits its current value synchronously. If the IO dispatcher thread starts executing before the main thread finishes initializing the remaining properties, the coroutine sees `null`.

## Fix
Moved the `init{}` block to after `lowerIndexByLang` (the last property it accesses), ensuring all fields are initialized before the coroutine collector runs.

## Steps to reproduce
1. Install Dictate keyboard
2. Open any text input
3. Crash occurs when `GlideDictionaryManager.installedVersion` StateFlow emits (on IO thread, before properties are initialized)

The crash is timing-dependent — more likely on slower devices or under memory pressure.