### PR TITLE
Add Cerebras fast rewording provider

### DIFF
--- a/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/ProviderRegistryTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/dictate/ProviderRegistryTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.dictate
+
+import dev.patrickgold.florisboard.dictate.provider.ProviderRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ProviderRegistryTest {
+
+    @Test
+    fun cerebrasIsAvailableAsFastRewordingProvider() {
+        val preset = assertNotNull(ProviderRegistry.byId("cerebras"))
+
+        assertEquals("Cerebras", preset.displayName)
+        assertEquals("https://api.cerebras.ai/v1/", preset.baseUrl)
+        assertEquals("https://cloud.cerebras.ai/", preset.apiKeyUrl)
+        assertTrue(preset.capabilities.chat)
+        assertFalse(preset.capabilities.transcription)
+        assertTrue(preset.supportsDynamicModels)
+        assertEquals("gemma-4-31b", preset.defaultChatModel)
+        assertTrue("gemma-4-31b" in preset.curatedChatModels)
+        assertTrue(preset in ProviderRegistry.presets)
+    }
+}

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiCompatibleClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiCompatibleClient.kt
@@ -39,8 +39,8 @@ import javax.net.ssl.X509TrustManager
 
 /**
  * A single client implementation that talks to any OpenAI Chat Completions / Audio Transcriptions
- * compatible endpoint. This one class covers OpenAI, Groq, OpenRouter, Together, DeepInfra, Mistral,
- * xAI, DeepSeek, local Ollama and arbitrary custom servers – they only differ by base URL, key and
+ * compatible endpoint. This one class covers OpenAI, Groq, Cerebras, OpenRouter, Together, DeepInfra,
+ * Mistral, xAI, DeepSeek, local Ollama and arbitrary custom servers – they only differ by base URL, key and
  * a few headers (see [ProviderRegistry] and [ProviderConfig]).
  *
  * Google Gemini is also handled here: chat/rewording goes through its OpenAI-compatible layer

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderRegistry.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderRegistry.kt
@@ -109,6 +109,24 @@ object ProviderRegistry {
         ),
     )
 
+    /**
+     * Cerebras Inference is chat-only here. Its OpenAI-compatible API is a strong fit for
+     * low-latency cleanup prompts after dictation; Gemma 4 31B is the fast default suggested for
+     * punctuation, filler-word removal and light grammar correction.
+     */
+    val CEREBRAS = ProviderPreset(
+        id = "cerebras",
+        displayName = "Cerebras",
+        baseUrl = "https://api.cerebras.ai/v1/",
+        capabilities = CHAT_ONLY,
+        supportsDynamicModels = true,
+        apiKeyUrl = "https://cloud.cerebras.ai/",
+        defaultChatModel = "gemma-4-31b",
+        curatedChatModels = listOf(
+            "gemma-4-31b", "gpt-oss-120b", "zai-glm-4.7",
+        ),
+    )
+
     val OPENROUTER = ProviderPreset(
         id = "openrouter",
         displayName = "OpenRouter",
@@ -376,7 +394,7 @@ object ProviderRegistry {
 
     /** All built-in presets in display order. The custom option is added by the UI on top of these. */
     val presets: List<ProviderPreset> = listOf(
-        OPENAI, GROQ, OPENROUTER, GEMINI, ANTHROPIC, TOGETHER, DEEPINFRA, MISTRAL, SONIOX,
+        OPENAI, GROQ, CEREBRAS, OPENROUTER, GEMINI, ANTHROPIC, TOGETHER, DEEPINFRA, MISTRAL, SONIOX,
         ELEVENLABS, DEEPGRAM, ASSEMBLYAI, XAI, DEEPSEEK, OLLAMA, LOCAL,
     )
 


### PR DESCRIPTION
## Summary

This PR implements the practical path suggested by MyButtermilk in #171: add a very fast built-in provider option for post-dictation cleanup/rewording instead of immediately expanding every prompt with its own provider/model routing.

Changes:
- Add `Cerebras` as a built-in chat-only provider preset.
- Default Cerebras rewording/chat requests to `gemma-4-31b`.
- Expose a small curated Cerebras chat model list: `gemma-4-31b`, `gpt-oss-120b`, and `zai-glm-4.7`.
- Keep Cerebras out of transcription flows by marking it `CHAT_ONLY`.
- Reuse the existing OpenAI-compatible client via `https://api.cerebras.ai/v1/`.
- Add a focused registry test to prevent the preset from regressing.

Refs #171.

## Why this is valuable

Issue #171 discusses per-prompt provider/model selection for rewording prompts. MyButtermilk's comment points out that the largest immediate UX win may not require full per-prompt routing: common post-dictation cleanup tasks are short, repetitive, and latency-sensitive. Punctuation cleanup, filler-word removal, and light grammar correction benefit most from a provider/model path that starts quickly and returns quickly.

Cerebras is a good fit for that narrow path because its inference API is OpenAI-compatible, so Dictate can reuse the existing provider infrastructure instead of adding new request plumbing. That keeps this change small while still giving users a fast rewording target. The selected default, `gemma-4-31b`, follows the model suggested in the issue discussion and is listed in Cerebras' model catalog.

This improves the app in a few concrete ways:
- Users get a dedicated low-latency cleanup provider without configuring a custom endpoint by hand.
- The existing provider selection UI can surface Cerebras automatically through the registry.
- Transcription provider lists stay correct because Cerebras is registered as chat-only.
- The implementation avoids prompt/profile migrations and avoids increasing the complexity of the prompt editor.
- Future per-prompt routing can still build on this provider preset if the larger feature is implemented later.

## Intentional scope

This PR intentionally does not implement full per-prompt provider/model selection. It also does not add provider-specific temperature, max-token, or streaming controls yet. Cerebras supports streaming, but Dictate's current provider preset model is focused on provider capabilities and model defaults, so adding streaming/parameter policy would be a separate UI/configuration change.

Keeping this PR focused makes it easier to review and gives users the main performance-oriented option requested in the issue discussion without expanding the data model.

## Validation

Ran:

```bash
./gradlew.bat :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.dictate.ProviderRegistryTest" :app:compileDebugKotlin :lib:dictate-core:compileDebugKotlin :wear:compileDebugKotlin
```

Result: build successful, including `ProviderRegistryTest > cerebrasIsAvailableAsFastRewordingProvider()`.

Also ran `git diff --check` successfully.

## References

- Issue discussion: https://github.com/DevEmperor/DictateKeyboard/issues/171
- Cerebras OpenAI compatibility docs: https://inference-docs.cerebras.ai/resources/openai
- Cerebras model catalog: https://inference-docs.cerebras.ai/models/overview
- Cerebras API keys docs: https://inference-docs.cerebras.ai/console/api-keys
- Cerebras streaming docs: https://inference-docs.cerebras.ai/capabilities/streaming