### PR TITLE
Refresh README for current Dictate features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 # Dictate Keyboard
 
-### Speak instead of type — in any app.
+### Speak instead of type - in any app.
 
-A powerful Whisper AI keyboard for dictation, real-time transcription and typing.
+An AI dictation keyboard for Android with real-time transcription, offline speech-to-text,
+AI rewriting, Wear OS support and a full FlorisBoard-based typing experience.
 
 <p>
   <a href="https://github.com/DevEmperor/DictateKeyboard/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/DevEmperor/DictateKeyboard?color=30B7E6&labelColor=1b1e2b&label=release"></a>
@@ -20,12 +21,13 @@ A powerful Whisper AI keyboard for dictation, real-time transcription and typing
 <p>
   <img alt="Kotlin" src="https://img.shields.io/badge/Kotlin-7F52FF?logo=kotlin&logoColor=white">
   <img alt="Jetpack Compose" src="https://img.shields.io/badge/Jetpack%20Compose-4285F4?logo=jetpackcompose&logoColor=white">
+  <img alt="FlorisBoard" src="https://img.shields.io/badge/Built%20on-FlorisBoard-30B7E6">
 </p>
 
 <table align="center">
   <tr>
-    <td valign="middle"><a href="https://play.google.com/store/apps/details?id=net.devemperor.dictate"><img alt="Get it on Google Play" width="300" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"/></a></td>
-    <td valign="middle"><a href="https://paypal.me/DevEmperor"><img alt="Donate with PayPal" width="200" src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_150x38.png"/></a></td>
+    <td valign="middle"><a href="https://play.google.com/store/apps/details?id=net.devemperor.dictate"><img alt="Get it on Google Play" width="300" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"></a></td>
+    <td valign="middle"><a href="https://paypal.me/DevEmperor"><img alt="Donate with PayPal" width="200" src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/PP_logo_h_150x38.png"></a></td>
   </tr>
 </table>
 
@@ -33,167 +35,170 @@ A powerful Whisper AI keyboard for dictation, real-time transcription and typing
 
 ---
 
-> **Note:** This is a complete rebuild of Dictate as a full, standalone keyboard on top of
-> [**FlorisBoard**](https://github.com/florisboard/florisboard), replacing the original Java
-> app that powered Dictate v1–v3. The previous Java codebase is preserved on the
+> [!NOTE]
+> Dictate Keyboard is a complete rebuild of Dictate as a standalone keyboard on top of
+> [FlorisBoard](https://github.com/florisboard/florisboard). It replaces the original Java app
+> from Dictate v1-v3; that codebase is preserved on the
 > [`legacy-java`](https://github.com/DevEmperor/Dictate/tree/legacy-java) branch.
 
----
-
-## 🎬 See it in action
+## See It In Action
 
 <table>
   <tr>
     <td width="330" align="center">
-      <img src="img/dictate_demo.gif" alt="Dictate in action" width="300">
+      <a href="img/dictate_demo.gif"><img src="img/dictate_demo.gif" alt="Dictate demo video" width="300"></a>
     </td>
     <td valign="middle">
-      <h3>Speak, and it's typed.</h3>
-      Tap the mic, talk naturally, and watch clean, punctuated text land in <b>any</b> app —
-      in real time. Prefer keys? Glide-type with word suggestions and autocorrect. Need it
-      more formal, translated or summarised? Hand it to an AI rewording prompt.
+      <h3>Tap the mic. Talk naturally. Get clean text.</h3>
+      Dictate can type live while you speak, insert the final transcript into the active app,
+      rewrite it with AI prompts, or stay fully offline with on-device models. It is not a
+      voice note app - it is a keyboard built around speech.
+      <br><br>
+      <a href="img/dictate_demo.gif"><b>Watch the demo</b></a>
     </td>
   </tr>
 </table>
 
-<br>
-
-## 📸 Screenshots
+## Screenshots
 
 <table>
   <tr>
-    <td><img src="img/banner_01_en-EN.png" width="175"></td>
-    <td><img src="img/banner_02_en-EN.png" width="175"></td>
-    <td><img src="img/banner_07_en-EN.png" width="175"></td>
-    <td><img src="img/banner_04_en-EN.png" width="175"></td>
+    <td><img src="img/banner_01_en-EN.png" alt="Dictate screenshot 1" width="175"></td>
+    <td><img src="img/banner_02_en-EN.png" alt="Dictate screenshot 2" width="175"></td>
+    <td><img src="img/banner_07_en-EN.png" alt="Dictate screenshot 3" width="175"></td>
+    <td><img src="img/banner_04_en-EN.png" alt="Dictate screenshot 4" width="175"></td>
   </tr>
   <tr>
-    <td><img src="img/banner_03_en-EN.png" width="175"></td>
-    <td><img src="img/banner_05_en-EN.png" width="175"></td>
-    <td><img src="img/banner_06_en-EN.png" width="175"></td>
-    <td><img src="img/banner_08_en-EN.png" width="175"></td>
+    <td><img src="img/banner_03_en-EN.png" alt="Dictate screenshot 5" width="175"></td>
+    <td><img src="img/banner_05_en-EN.png" alt="Dictate screenshot 6" width="175"></td>
+    <td><img src="img/banner_06_en-EN.png" alt="Dictate screenshot 7" width="175"></td>
+    <td><img src="img/banner_08_en-EN.png" alt="Dictate screenshot 8" width="175"></td>
   </tr>
 </table>
 
-<br>
+## Why Dictate Is Different
 
-## 📲 Installation
+| Ordinary voice input | Dictate Keyboard |
+| --- | --- |
+| Usually tied to one keyboard or one provider | Works as a full keyboard, a classic voice-first panel, a floating button and a Wear OS keyboard |
+| Sends audio to a fixed service | Lets you choose cloud providers, OpenAI-compatible endpoints or offline on-device models |
+| Gives a raw transcript | Can clean up, translate, summarize, reword, format and auto-fix text before it lands |
+| Stops when another keyboard is active | Floating button lets you dictate into apps while keeping your favorite keyboard open |
+| Disappears after insertion | Keeps history, stats, resend options and failure recovery for real daily use |
 
-**The app is available on [Google Play](https://play.google.com/store/apps/details?id=net.devemperor.dictate)**
-(for a small fee that supports continued development), giving you easy installation and free
-lifetime updates. Just tap the badge above or [this link](https://play.google.com/store/apps/details?id=net.devemperor.dictate).
+> [!IMPORTANT]
+> Dictate does not bundle a hidden speech service. You choose the provider and API key.
+> Offline models keep transcription on your device; cloud mode sends audio only to the provider you configure.
 
-> **Existing users:** the new keyboard keeps the same app identity and signing key, so your
-> settings carry over on update — no reinstall, no lost configuration.
+## Core Features
 
-<br>
+### Speech-To-Text That Fits Your Workflow
 
-## ✨ What is Dictate?
+- **Tap-to-dictate anywhere:** speak into chats, notes, browsers, search fields, forms and productivity apps.
+- **Real-time transcription:** watch text appear while you talk with supported streaming providers.
+- **Fast batch transcription:** record first, then send the finished audio to the selected provider.
+- **Offline transcription:** download on-device Whisper or NVIDIA Parakeet models for private, no-network dictation.
+- **File transcription:** transcribe existing audio or video files instead of only recording live speech.
+- **Language-aware dictation:** pick a dictation language or let the model auto-detect.
+- **Custom words and context:** bias recognition toward names, jargon and recurring terms.
+- **Silence detection:** skip empty recordings before they waste an upload or produce hallucinated text.
+- **Audio controls:** pause/resume, cancel, retry kept audio, use Bluetooth/voice-communication sources and optional audio focus.
+- **Haptic feedback:** optional vibration cues for recording, transcription and rewording state changes.
 
-**Dictate** is an easy-to-use keyboard for transcribing and dictating. It uses
-[OpenAI Whisper](https://openai.com/index/whisper/) in the background, which delivers
-extremely accurate results for
-[many different languages](https://platform.openai.com/docs/guides/speech-to-text/supported-languages),
-complete with punctuation — plus custom AI rewording powered by leading models from OpenAI,
-Google Gemini and many other providers.
+### AI Rewriting Built Into The Keyboard
 
-Instead of pecking at keys, just tap the microphone, speak, and watch your words appear —
-now in real time — as clean, formatted text in any app. Prefer to type? Dictate is a
-complete keyboard too, with glide typing, word suggestions and autocorrect. Need the text
-more formal, translated, summarised, or fixed-up? Hand it to a rewording prompt and let the
-model do the work. With the floating button you can even dictate straight into apps while
-another keyboard is open.
+- **Prompt chips:** tap saved actions like fix grammar, make formal, summarize, translate or your own custom instruction.
+- **Selection rewriting:** select text in any app and rework it in place.
+- **Live prompts:** speak an instruction and send it straight to the rewording model.
+- **Auto-formatting:** turn spoken punctuation, structure and formatting cues into cleaner text.
+- **Auto-apply prompts:** run chosen prompts automatically after each dictation.
+- **Per-prompt reasoning effort:** tune reasoning for expensive or complex rewrite prompts without changing the global default.
+- **Snippets:** save reusable text snippets that insert instantly without an API call.
+- **Community prompt library:** install shared prompts in a tap, or publish your own.
 
-<br>
+### A Complete Keyboard, Not A Dictation Overlay
 
-## 🎤 Features
+- **Full FlorisBoard typing:** glide typing, word suggestions, spell check, autocorrect and rich layout support.
+- **Better autocorrect:** keyboard-proximity ranking plus per-language bigram context for more useful corrections.
+- **Language data management:** dictionary and context-model status is visible in subtype settings.
+- **Classic voice-first layout:** use the old Dictate-style keyboard-free panel, lock it in, or swipe back to the full keyboard.
+- **Floating button:** dictate while another keyboard is active, with draggable placement, edge snapping, waveform preview, styles and long-press rewording.
+- **Wear OS keyboard:** dictate from your watch, tethered through the phone or standalone with synced settings.
+- **Keyboard utilities:** emoji keyboard, clipboard, cursor tools, select-all toggle, one-handed mode, themes, sounds and haptics.
 
-- **Voice dictation with Whisper AI** — highly accurate speech-to-text in dozens of languages, with automatic punctuation. It's so sensitive you can literally *whisper* and still get a clean transcription.
-- **Real-time transcription** — watch your words appear live as you speak, streaming from OpenAI, Deepgram, Soniox, AssemblyAI or ElevenLabs.
-- **On-device transcription** — dictate completely offline with a downloadable on-device model (Whisper or NVIDIA Parakeet): no internet needed and nothing ever leaves your phone.
-- **Glide typing, suggestions & autocorrect** — Dictate is now a complete typing keyboard too: swipe across the keys to type whole words, with per-language dictionaries, word suggestions, spell check and autocorrect.
-- **Classic keyboard-free dictation layout** — bring back the pure, voice-first screen from Dictate 3: lock it in, or keep it just a swipe away from the full keyboard.
-- **Wear OS keyboard** — dictate straight from your watch, tethered through your phone or fully standalone.
-- **Floating dictation button** — dictate straight into **any** app, even when another keyboard is active. Pick from three styles (Pill, Ring, Orb), watch a live waveform while you speak, drag it anywhere with edge-snapping, set its color and size, and long-press to reword.
-- **AI rewording & rewriting** — turn a selection into something more formal, casual, translated, summarised, or anything you define with custom prompts, with adjustable reasoning effort.
-- **Community prompt library** — browse rewording prompts shared by others and install them in a tap, or publish your own.
-- **Dictation statistics** — track how much you've dictated and typed, with milestones and a home-screen overview.
-- **Find & replace rules** — automatically fix recurring words, names or phrases in every transcript.
-- **Single-call multimodal mode** — let one audio-capable AI model transcribe *and* format in a single request, for lower latency and cost.
-- **Custom prompts & snippets** — build your own reword actions; reusable text snippets are inserted instantly without an API call.
-- **Bring your own key & provider** — use your own API key with OpenAI, Google Gemini, Groq, Mistral, OpenRouter, Soniox, Deepgram, AssemblyAI, ElevenLabs and other compatible endpoints, so you stay in control of usage and cost.
-- **A real, full keyboard** *(courtesy of the FlorisBoard base):*
-  - Huge variety of keyboard layouts and easy language/subtype switching
-  - Full theme customization with day/night presets, automatic switching and a high-contrast E-Reader theme
-  - Emoji keyboard, clipboard manager & cursor tools
-  - One-handed / compact mode, gesture actions, customizable key sound & haptic feedback
-- **Privacy-respecting by design** — no tracking; your audio goes only to the AI provider you configure.
+### Control, Reliability And History
 
-<p align="center"><i>Bring your own API key — Dictate works with:</i></p>
+- **Provider accounts:** keep separate settings for transcription and rewording providers.
+- **Single-call multimodal mode:** send audio to an audio-capable chat model that transcribes and formats in one request.
+- **Find and replace rules:** automatically fix names, phrases and common recognition mistakes.
+- **Transcription history:** review recent dictations, source, model, language and status.
+- **Usage statistics:** track dictated and typed volume with milestone nudges.
+- **Resend and recovery:** retry failed or interrupted recordings instead of losing speech.
+- **Proxy and certificate options:** support custom network setups, including user-installed certificates.
+- **Backup-aware data:** history and settings are handled with app backup/restore behavior in mind.
+
+## Supported Providers
+
+Bring your own API key, choose the provider per use case, or point Dictate at a compatible custom endpoint.
+
+<p align="center"><i>Speech-to-text providers (real-time on supported services)</i></p>
 <p align="center">
   <img alt="OpenAI" src="https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white">
-  <img alt="Google Gemini" src="https://img.shields.io/badge/Google%20Gemini-4285F4?logo=googlegemini&logoColor=white">
   <img alt="Groq" src="https://img.shields.io/badge/Groq-F55036">
+  <img alt="Google Gemini" src="https://img.shields.io/badge/Google%20Gemini-4285F4?logo=googlegemini&logoColor=white">
+  <img alt="Mistral" src="https://img.shields.io/badge/Mistral-FA520F">
+  <img alt="OpenRouter" src="https://img.shields.io/badge/OpenRouter-6467F2">
+  <img alt="Soniox" src="https://img.shields.io/badge/Soniox-2A6DF4">
   <img alt="Deepgram" src="https://img.shields.io/badge/Deepgram-13EF93?labelColor=101820">
   <img alt="AssemblyAI" src="https://img.shields.io/badge/AssemblyAI-5D5DFF">
   <img alt="ElevenLabs" src="https://img.shields.io/badge/ElevenLabs-111111">
-  <img alt="Soniox" src="https://img.shields.io/badge/Soniox-2A6DF4">
-  <img alt="Mistral" src="https://img.shields.io/badge/Mistral-FA520F">
-  <img alt="OpenRouter" src="https://img.shields.io/badge/OpenRouter-6467F2">
-  <img alt="Ollama" src="https://img.shields.io/badge/Ollama-111111?logo=ollama&logoColor=white">
-  <img alt="and more" src="https://img.shields.io/badge/%2B%20more-30B7E6">
+  <img alt="On-device" src="https://img.shields.io/badge/On--device-Whisper%20%2B%20Parakeet-30B7E6">
 </p>
 
-<br>
+<p align="center"><i>AI rewriting and prompts</i></p>
+<p align="center">
+  <img alt="OpenAI" src="https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white">
+  <img alt="Anthropic Claude" src="https://img.shields.io/badge/Anthropic%20Claude-191919">
+  <img alt="Google Gemini" src="https://img.shields.io/badge/Google%20Gemini-4285F4?logo=googlegemini&logoColor=white">
+  <img alt="Groq" src="https://img.shields.io/badge/Groq-F55036">
+  <img alt="Mistral" src="https://img.shields.io/badge/Mistral-FA520F">
+  <img alt="OpenRouter" src="https://img.shields.io/badge/OpenRouter-6467F2">
+  <img alt="xAI" src="https://img.shields.io/badge/xAI-111111">
+  <img alt="DeepSeek" src="https://img.shields.io/badge/DeepSeek-4D6BFE">
+  <img alt="Together AI" src="https://img.shields.io/badge/Together%20AI-111111">
+  <img alt="DeepInfra" src="https://img.shields.io/badge/DeepInfra-111111">
+  <img alt="Ollama" src="https://img.shields.io/badge/Ollama-111111?logo=ollama&logoColor=white">
+  <img alt="Custom OpenAI-compatible endpoint" src="https://img.shields.io/badge/Custom%20endpoint-OpenAI--compatible-30B7E6">
+</p>
 
-## 🧱 Built on FlorisBoard
+## Installation
 
-Dictate Keyboard is a fork of [**FlorisBoard**](https://github.com/florisboard/florisboard),
-an open-source, privacy-respecting keyboard created by
-[Patrick Goldinger](https://github.com/patrickgold) and
-[The FlorisBoard Contributors](https://github.com/florisboard/florisboard/graphs/contributors).
-Their work provides the entire keyboard foundation — layouts, theming, gesture handling,
-clipboard tools and the IME plumbing — on top of which Dictate adds its voice-dictation and
-AI-rewording layer.
+**Dictate is available on [Google Play](https://play.google.com/store/apps/details?id=net.devemperor.dictate)**
+for a small fee that supports continued development and includes lifetime updates.
 
-Huge thanks to the FlorisBoard team. FlorisBoard is licensed under the Apache License 2.0;
-see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) for full attribution.
+> [!TIP]
+> Existing Dictate users can update in place. The new keyboard keeps the same app identity and signing key,
+> so settings migrate without reinstalling.
 
-<br>
+## Built On FlorisBoard
 
-## 🤝 Contributing
+Dictate Keyboard stands on the excellent open-source foundation of
+[FlorisBoard](https://github.com/florisboard/florisboard): layouts, theming, gestures, clipboard,
+emoji, IME plumbing and many keyboard fundamentals. Dictate adds the voice, provider, prompt,
+floating-button, Wear OS and rewording layers on top.
 
-The best way to help right now is to **[open an issue](https://github.com/DevEmperor/DictateKeyboard/issues)**
-with bug reports, ideas or feedback. Full contribution and community guidelines will be
-published as the project matures. Thank you! 🙏
+## Support Development
 
-<br>
+Dictate is open source and built in spare time. The most direct ways to support continued work are:
 
-## 📄 License & attribution
+- [Buy the app on Google Play](https://play.google.com/store/apps/details?id=net.devemperor.dictate)
+- [Sponsor DevEmperor on GitHub](https://github.com/sponsors/DevEmperor)
+- [Donate via PayPal](https://paypal.me/DevEmperor)
 
-Dictate Keyboard is released under the terms of the
-[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
-
-- This project is a fork of **FlorisBoard** — Copyright © The FlorisBoard Contributors,
-  licensed under Apache-2.0.
-- See [`LICENSE`](LICENSE) for the full license text and [`NOTICE`](NOTICE) for required
-  attribution notices.
-- Speech recognition is powered by [OpenAI Whisper](https://openai.com/index/whisper/).
-
-<br>
-
-## ❤️ Support &amp; sponsors
-
-Dictate is free and open source, built in my spare time. If it makes your day a little
-easier, you can support development by
-[buying the app on Google Play](https://play.google.com/store/apps/details?id=net.devemperor.dictate),
-[sponsoring me on GitHub](https://github.com/sponsors/DevEmperor),
-or [donating via PayPal](https://paypal.me/DevEmperor). Every bit helps — thank you! 🙏
-
-**Dictate's very first sponsor — thank you!** 🎉
+**Dictate's first sponsor - thank you.**
 
 <!-- SPONSORS:START -->
 <p>
-  <a href="https://github.com/cnfatman"><img src="https://github.com/cnfatman.png" width="72" alt="Codename: Fatman" title="Codename: Fatman — Dictate's first sponsor 💖"></a>
+  <a href="https://github.com/cnfatman"><img src="https://github.com/cnfatman.png" width="72" alt="Codename: Fatman" title="Codename: Fatman - Dictate's first sponsor"></a>
 </p>
 <!-- SPONSORS:END -->


### PR DESCRIPTION
## Summary

Refreshes the README so it matches the current Dictate Keyboard feature set and reads more like a concise product page than a historical project note.

What changed:
- Reworked the hero copy around the current value proposition: AI dictation keyboard, realtime transcription, offline STT, AI rewriting, Wear OS and full FlorisBoard typing.
- Kept the existing logo, Google Play CTA, PayPal CTA, demo GIF/video link and screenshot grid.
- Added a clear "Why Dictate is different" comparison table.
- Added GFM admonitions for the FlorisBoard rebuild note, provider/privacy expectations and upgrade tip.
- Expanded feature coverage for recent work: realtime transcription, on-device Whisper/Parakeet, file transcription, floating button, Wear OS, classic voice-first layout, prompt chips, live prompts, per-prompt reasoning, custom words, history, stats, resend/recovery, proxy/certificate options and backup-aware data.
- Split supported providers into speech-to-text and AI rewriting groups so users quickly understand what they can connect.
- Removed dedicated Contributing / License-style README sections because those belong in the repo's dedicated files.

## Why this helps

The old README was partly accurate but undersold several major additions that have landed recently. New users should be able to understand, in the first screen and first few sections, that Dictate is not just another voice note app or a basic Whisper wrapper. It is a full Android keyboard that can also float above other keyboards, run on Wear OS, work offline, use multiple providers and post-process text with reusable prompts.

The new structure keeps the README concise while making the conversion path clearer:
- understand the product quickly,
- see the demo and screenshots,
- understand the differentiators,
- scan the full feature set,
- verify provider support,
- install or support development.

## Validation

- Checked `git diff --check` successfully.
- Verified all local README image/demo references exist.
- Documentation-only change; no Gradle tests were run.