### PR TITLE
Fix missing first words in realtime dictation

### DIFF
--- a/lib/dictate-core/build.gradle.kts
+++ b/lib/dictate-core/build.gradle.kts
@@ -63,6 +63,12 @@ configure<LibraryExtension> {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+
+    testOptions {
+        unitTests.all {
+            it.useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {
@@ -72,4 +78,5 @@ dependencies {
     api(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.androidx.core.ktx)
+    testImplementation(libs.kotlin.test.junit5)
 }

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeAudioGate.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeAudioGate.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.dictate.provider
+
+import java.util.ArrayDeque
+
+/**
+ * Preserves microphone audio while a realtime provider completes a mandatory handshake.
+ *
+ * Some providers require a config/setup exchange before the first audio frame. The microphone is already
+ * running by then, so dropping those early frames cuts off the first word on an ordinary network and can
+ * lose several words on a slow connection. This gate copies the reused capture buffers until [markReady],
+ * then flushes them in order before allowing live frames through.
+ *
+ * The buffer is deliberately bounded. One MiB holds more than 30 seconds of 16 kHz mono PCM16, comfortably
+ * beyond the WebSocket connect timeout; if a provider never completes its setup, the parallel WAV remains
+ * the lossless batch fallback without letting this queue grow for the whole recording.
+ */
+internal class RealtimeAudioGate(
+    private val maxBufferedBytes: Int = DEFAULT_MAX_BUFFERED_BYTES,
+) {
+    private val pendingAudio = ArrayDeque<ByteArray>()
+    private var bufferedBytes = 0
+    private var ready = false
+    private var finishRequested = false
+    private var finished = false
+    private var closed = false
+
+    init {
+        require(maxBufferedBytes > 0) { "maxBufferedBytes must be positive" }
+    }
+
+    /** Queues a defensive copy before setup, or sends synchronously once setup has completed. */
+    fun sendAudio(pcm16: ByteArray, len: Int, send: (ByteArray, Int) -> Unit) {
+        val safeLen = len.coerceIn(0, pcm16.size)
+        if (safeLen == 0) return
+        synchronized(this) {
+            if (closed || finished) return
+            if (ready) {
+                send(pcm16, safeLen)
+            } else if (bufferedBytes + safeLen <= maxBufferedBytes) {
+                pendingAudio.addLast(pcm16.copyOf(safeLen))
+                bufferedBytes += safeLen
+            }
+        }
+    }
+
+    /** Flushes pending frames in capture order, then honors an end request made during setup. */
+    fun markReady(send: (ByteArray, Int) -> Unit, finish: () -> Unit) {
+        synchronized(this) {
+            if (closed || ready) return
+            ready = true
+            while (pendingAudio.isNotEmpty()) {
+                val pcm16 = pendingAudio.removeFirst()
+                send(pcm16, pcm16.size)
+            }
+            bufferedBytes = 0
+            if (finishRequested) {
+                finished = true
+                finish()
+            }
+        }
+    }
+
+    /** Sends the provider's end marker now, or defers it until after setup and buffered audio. */
+    fun finish(sendFinish: () -> Unit) {
+        synchronized(this) {
+            if (closed || finished) return
+            if (ready) {
+                finished = true
+                sendFinish()
+            } else {
+                finishRequested = true
+            }
+        }
+    }
+
+    /** Discards pending audio and ignores late setup callbacks after cancellation/failure/close. */
+    fun close() {
+        synchronized(this) {
+            closed = true
+            pendingAudio.clear()
+            bufferedBytes = 0
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_MAX_BUFFERED_BYTES = 1024 * 1024
+    }
+}

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
@@ -234,7 +234,7 @@ private class SonioxRealtimeSession(
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private var ws: WebSocket? = null
     private val permanent = StringBuilder()
-    @Volatile private var started = false   // config text must be the first frame — gate audio until sent
+    private val audioGate = RealtimeAudioGate()
     @Volatile private var done = false
 
     private companion object { const val URL = "wss://stt-rt.soniox.com/transcribe-websocket" }
@@ -246,7 +246,12 @@ private class SonioxRealtimeSession(
     private val listener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
             webSocket.send(config())
-            started = true
+            // Soniox requires the config text to be the first frame. Replay every microphone frame
+            // captured while the socket connected immediately after it, instead of losing the start.
+            audioGate.markReady(
+                send = { pcm16, len -> runCatching { webSocket.send(pcm16.toByteString(0, len)) } },
+                finish = { runCatching { webSocket.send("") } },
+            )
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
@@ -282,16 +287,19 @@ private class SonioxRealtimeSession(
     }.toString()
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
-        if (!started) return   // drop audio captured before the config frame was sent
-        runCatching { ws?.send(pcm16.toByteString(0, len)) }
+        audioGate.sendAudio(pcm16, len) { audio, length ->
+            runCatching { ws?.send(audio.toByteString(0, length)) }
+        }
     }
 
     override fun finish() {
-        val socket = ws ?: return finalizeAndClose(null)
-        runCatching { socket.send("") }   // empty frame → flush + finished
+        audioGate.finish {
+            runCatching { ws?.send("") }   // empty frame → flush + finished
+        }
     }
 
     override fun cancel() {
+        audioGate.close()
         done = true
         runCatching { ws?.close(1000, null) }
         callbacks.onClosed()
@@ -300,6 +308,7 @@ private class SonioxRealtimeSession(
     private fun emitError(t: Throwable) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { ws?.cancel() }
         callbacks.onError(t)
         callbacks.onClosed()
@@ -308,6 +317,7 @@ private class SonioxRealtimeSession(
     private fun finalizeAndClose(webSocket: WebSocket?) {
         if (done) return
         done = true
+        audioGate.close()
         if (permanent.isNotEmpty()) callbacks.onFinalSegment(permanent.toString())
         runCatching { (webSocket ?: ws)?.close(1000, null) }
         callbacks.onClosed()
@@ -500,7 +510,7 @@ private class GeminiRealtimeSession(
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private var ws: WebSocket? = null
     private val transcript = StringBuilder()
-    @Volatile private var started = false    // gate audio until the server acks setup (setupComplete)
+    private val audioGate = RealtimeAudioGate()
     @Volatile private var finishing = false
     @Volatile private var done = false
 
@@ -527,7 +537,14 @@ private class GeminiRealtimeSession(
 
     private fun handle(webSocket: WebSocket, text: String) {
         val obj = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: return
-        if (obj.containsKey("setupComplete")) started = true   // now safe to stream audio
+        if (obj.containsKey("setupComplete")) {
+            // Gemini also forbids audio before setupComplete. Preserve and replay the mic startup rather
+            // than dropping it while waiting for the server acknowledgement.
+            audioGate.markReady(
+                send = { pcm16, len -> sendAudioFrame(webSocket, pcm16, len) },
+                finish = { sendAudioEnd(webSocket) },
+            )
+        }
         val server = obj["serverContent"]?.jsonObject
         server?.get("inputTranscription")?.jsonObject?.get("text")?.jsonPrimitive?.content?.let { chunk ->
             if (chunk.isNotEmpty()) {
@@ -551,7 +568,12 @@ private class GeminiRealtimeSession(
     }.toString()
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
-        if (!started) return   // wait for setupComplete before streaming audio (Gemini Live requirement)
+        audioGate.sendAudio(pcm16, len) { audio, length ->
+            ws?.let { sendAudioFrame(it, audio, length) }
+        }
+    }
+
+    private fun sendAudioFrame(socket: WebSocket, pcm16: ByteArray, len: Int) {
         val msg = buildJsonObject {
             putJsonObject("realtimeInput") {
                 putJsonObject("audio") {
@@ -560,16 +582,22 @@ private class GeminiRealtimeSession(
                 }
             }
         }.toString()
-        runCatching { ws?.send(msg) }
+        runCatching { socket.send(msg) }
     }
 
-    override fun finish() {
-        val socket = ws ?: return finalizeAndClose(null)
-        finishing = true
+    private fun sendAudioEnd(socket: WebSocket) {
         runCatching { socket.send("""{"realtimeInput":{"audioStreamEnd":true}}""") }
     }
 
+    override fun finish() {
+        finishing = true
+        audioGate.finish {
+            ws?.let { sendAudioEnd(it) }
+        }
+    }
+
     override fun cancel() {
+        audioGate.close()
         done = true
         runCatching { ws?.close(1000, null) }
         callbacks.onClosed()
@@ -578,6 +606,7 @@ private class GeminiRealtimeSession(
     private fun emitError(t: Throwable) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { ws?.cancel() }
         callbacks.onError(t)
         callbacks.onClosed()
@@ -586,6 +615,7 @@ private class GeminiRealtimeSession(
     private fun finalizeAndClose(webSocket: WebSocket?) {
         if (done) return
         done = true
+        audioGate.close()
         if (transcript.isNotEmpty()) callbacks.onFinalSegment(transcript.toString())
         runCatching { (webSocket ?: ws)?.close(1000, null) }
         callbacks.onClosed()

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
@@ -109,6 +109,7 @@ private class OpenAiRealtimeSession(
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private var ws: WebSocket? = null
     private val partial = StringBuilder()
+    private val audioGate = RealtimeAudioGate()
     @Volatile private var committing = false
     @Volatile private var done = false
 
@@ -129,6 +130,13 @@ private class OpenAiRealtimeSession(
     private val listener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
             webSocket.send(sessionUpdate())
+            // OkHttp accepts send() calls while a socket is still connecting. Without this gate, mic
+            // frames queued during the handshake precede this session.update and therefore arrive before
+            // OpenAI knows the intended PCM format/model. Put the config first, then replay the beginning.
+            audioGate.markReady(
+                send = { pcm16, len -> sendAudioFrame(webSocket, pcm16, len) },
+                finish = { sendCommit(webSocket) },
+            )
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
@@ -178,7 +186,12 @@ private class OpenAiRealtimeSession(
     }.toString()
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
-        val socket = ws ?: return
+        audioGate.sendAudio(pcm16, len) { audio, length ->
+            ws?.let { sendAudioFrame(it, audio, length) }
+        }
+    }
+
+    private fun sendAudioFrame(socket: WebSocket, pcm16: ByteArray, len: Int) {
         val b64 = Base64.encodeToString(pcm16, 0, len, Base64.NO_WRAP)
         val msg = buildJsonObject {
             put("type", "input_audio_buffer.append")
@@ -187,14 +200,20 @@ private class OpenAiRealtimeSession(
         runCatching { socket.send(msg) }
     }
 
-    override fun finish() {
-        val socket = ws ?: return finishClosed(null)
-        committing = true
-        // Flush the buffered audio; the server responds with the final `completed`, then we close.
+    private fun sendCommit(socket: WebSocket) {
         runCatching { socket.send("""{"type":"input_audio_buffer.commit"}""") }
     }
 
+    override fun finish() {
+        committing = true
+        // Flush the buffered audio; the server responds with the final `completed`, then we close.
+        audioGate.finish {
+            ws?.let { sendCommit(it) }
+        }
+    }
+
     override fun cancel() {
+        audioGate.close()
         done = true
         runCatching { ws?.close(1000, null) }
         callbacks.onClosed()
@@ -203,6 +222,7 @@ private class OpenAiRealtimeSession(
     private fun emitError(t: Throwable) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { ws?.cancel() }
         callbacks.onError(t)
         callbacks.onClosed()
@@ -211,6 +231,7 @@ private class OpenAiRealtimeSession(
     private fun finishClosed(webSocket: WebSocket?) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { (webSocket ?: ws)?.close(1000, null) }
         callbacks.onClosed()
     }
@@ -423,6 +444,7 @@ private class ElevenLabsRealtimeSession(
 
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private var ws: WebSocket? = null
+    private val audioGate = RealtimeAudioGate()
     @Volatile private var done = false
 
     fun connect() {
@@ -438,6 +460,12 @@ private class ElevenLabsRealtimeSession(
             val obj = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: return
             val body = obj["text"]?.jsonPrimitive?.content.orEmpty()
             when (obj["message_type"]?.jsonPrimitive?.content) {
+                // The official lifecycle starts media after this acknowledgement. Preserve everything the
+                // mic captured while connecting, then replay it once ElevenLabs confirms the session.
+                "session_started" -> audioGate.markReady(
+                    send = { pcm16, len -> sendAudioFrame(webSocket, pcm16, len) },
+                    finish = { sendCommit(webSocket) },
+                )
                 "partial_transcript" -> if (body.isNotBlank()) callbacks.onPartial(body)
                 "committed_transcript", "committed_transcript_with_timestamps" ->
                     if (body.isNotBlank()) callbacks.onFinalSegment(body)
@@ -452,17 +480,22 @@ private class ElevenLabsRealtimeSession(
     }
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
+        audioGate.sendAudio(pcm16, len) { audio, length ->
+            ws?.let { sendAudioFrame(it, audio, length) }
+        }
+    }
+
+    private fun sendAudioFrame(socket: WebSocket, pcm16: ByteArray, len: Int) {
         val msg = buildJsonObject {
             put("message_type", "input_audio_chunk")
             put("audio_base_64", Base64.encodeToString(pcm16, 0, len, Base64.NO_WRAP))
             put("commit", false)
             put("sample_rate", 16_000)
         }.toString()
-        runCatching { ws?.send(msg) }
+        runCatching { socket.send(msg) }
     }
 
-    override fun finish() {
-        val socket = ws ?: return finishClosed(null)
+    private fun sendCommit(socket: WebSocket) {
         val msg = buildJsonObject {
             put("message_type", "input_audio_chunk")
             put("audio_base_64", "")
@@ -471,7 +504,14 @@ private class ElevenLabsRealtimeSession(
         runCatching { socket.send(msg) }
     }
 
+    override fun finish() {
+        audioGate.finish {
+            ws?.let { sendCommit(it) }
+        }
+    }
+
     override fun cancel() {
+        audioGate.close()
         done = true
         runCatching { ws?.close(1000, null) }
         callbacks.onClosed()
@@ -480,6 +520,7 @@ private class ElevenLabsRealtimeSession(
     private fun emitError(t: Throwable) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { ws?.cancel() }
         callbacks.onError(t)
         callbacks.onClosed()
@@ -488,6 +529,7 @@ private class ElevenLabsRealtimeSession(
     private fun finishClosed(webSocket: WebSocket?) {
         if (done) return
         done = true
+        audioGate.close()
         runCatching { (webSocket ?: ws)?.close(1000, null) }
         callbacks.onClosed()
     }

--- a/lib/dictate-core/src/test/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeAudioGateTest.kt
+++ b/lib/dictate-core/src/test/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeAudioGateTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.dictate.provider
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class RealtimeAudioGateTest {
+
+    @Test
+    fun buffersDefensiveCopiesThenPassesLiveAudioThrough() {
+        val gate = RealtimeAudioGate()
+        val sent = mutableListOf<ByteArray>()
+        val reusedCaptureBuffer = byteArrayOf(1, 2, 3, 4)
+        val sender = { pcm16: ByteArray, len: Int -> sent += pcm16.copyOf(len) }
+
+        gate.sendAudio(reusedCaptureBuffer, 3, sender)
+        reusedCaptureBuffer.fill(9)
+        assertEquals(0, sent.size)
+
+        gate.markReady(sender) { error("unexpected finish") }
+        gate.sendAudio(byteArrayOf(5, 6), 2, sender)
+
+        assertEquals(2, sent.size)
+        assertContentEquals(byteArrayOf(1, 2, 3), sent[0])
+        assertContentEquals(byteArrayOf(5, 6), sent[1])
+    }
+
+    @Test
+    fun finishBeforeReadyFlushesAudioBeforeEndMarker() {
+        val gate = RealtimeAudioGate()
+        val events = mutableListOf<String>()
+
+        gate.sendAudio(byteArrayOf(1, 2), 2) { _, _ -> events += "audio" }
+        gate.finish { events += "finish" }
+        assertEquals(emptyList(), events)
+
+        gate.markReady(
+            send = { _, _ -> events += "audio" },
+            finish = { events += "finish" },
+        )
+        gate.sendAudio(byteArrayOf(3, 4), 2) { _, _ -> events += "late audio" }
+        gate.finish { events += "late finish" }
+
+        assertEquals(listOf("audio", "finish"), events)
+    }
+
+    @Test
+    fun bufferIsBoundedAndPreservesTheEarliestFrames() {
+        val gate = RealtimeAudioGate(maxBufferedBytes = 4)
+        val sent = mutableListOf<ByteArray>()
+        val sender = { pcm16: ByteArray, len: Int -> sent += pcm16.copyOf(len) }
+
+        gate.sendAudio(byteArrayOf(1, 2, 3), 3, sender)
+        gate.sendAudio(byteArrayOf(4, 5), 2, sender)
+        gate.markReady(sender) { error("unexpected finish") }
+
+        assertEquals(1, sent.size)
+        assertContentEquals(byteArrayOf(1, 2, 3), sent.single())
+    }
+
+    @Test
+    fun closeDropsPendingAudioAndIgnoresLateSetup() {
+        val gate = RealtimeAudioGate()
+        val events = mutableListOf<String>()
+
+        gate.sendAudio(byteArrayOf(1, 2), 2) { _, _ -> events += "audio" }
+        gate.finish { events += "finish" }
+        gate.close()
+        gate.markReady(
+            send = { _, _ -> events += "audio" },
+            finish = { events += "finish" },
+        )
+
+        assertEquals(emptyList(), events)
+    }
+}


### PR DESCRIPTION
## What users notice

If someone taps record and starts speaking immediately, realtime dictation can start in the middle of the sentence. The microphone indicator is already active, so this feels like the app ignored the first word.

| | Transcript |
|---|---|
| **Spoken** | “Go. Alpha Bravo Charlie Delta Echo Foxtrot.” |
| **Before** | “Delta Echo Foxtrot.” |
| **After** | “Go. Alpha Bravo Charlie Delta Echo Foxtrot.” |

In three live Soniox tests, opening the connection took 695–2,047 ms. The old behavior lost the beginning in all three runs; buffering the startup audio kept the complete sentence in all three.

## Why it happened

The microphone starts immediately, but some realtime providers are not ready for audio immediately. They first need either a configuration message or a server acknowledgement.

The app handled that short gap in two unsafe ways:

- Soniox and Gemini returned early from `sendAudio()`, permanently discarding everything captured before setup completed.
- OpenAI and ElevenLabs let audio enter the WebSocket queue before their documented session-start sequence was complete. With OpenAI, those frames could be ordered before `session.update`; with ElevenLabs, they could be sent before `session_started`.

So the problem was not microphone startup. The microphone had the audio, but the realtime session had no safe place to hold it yet.

## The fix

Add one small `RealtimeAudioGate` for providers with a startup handshake:

1. Capture audio from the first microphone frame.
2. Temporarily buffer it while the provider session starts.
3. Send the provider's required config/ack sequence first.
4. Replay the buffered beginning in capture order, then continue with live audio.

A very quick stop is deferred until the buffered audio has been sent. Cancel, failure, and close still clear it immediately.

## Provider audit

| Provider | Startup protocol | Result |
|---|---|---|
| OpenAI | Send `session.update` before `input_audio_buffer.append` | Fixed: config is queued first, then startup audio |
| Soniox | Configuration must be the first WebSocket message | Fixed: buffer until config is sent |
| ElevenLabs | Server emits `session_started` before media streaming | Fixed: buffer until acknowledgement |
| Deepgram | Configuration is already in URL parameters/headers | Safe as-is; official examples stream on open |
| AssemblyAI | Configuration is already in URL parameters/headers | Safe as-is; official examples stream on open |
| Gemini | Waits for `setupComplete` (currently disabled in the registry) | Fixed proactively with the same gate |
| Mistral | Realtime path is currently disabled | No active path to change |

This keeps Deepgram and AssemblyAI on their existing low-latency path instead of adding an unnecessary delay.

## Why this is low risk

- The gate is used only where message ordering or a readiness acknowledgement requires it.
- The queue is capped at 1 MiB, so it cannot grow for an entire recording.
- Capture buffers are copied because the recorder reuses them; frame order is preserved.
- The existing WAV recording and batch fallback are unchanged.
- There are no preference, database, public API, or provider wire-format changes.

## Validation

- Live Soniox `stt-rt-v5` probe: complete beginning in 3/3 buffered runs; missing beginning in 3/3 old-behavior runs.
- Audited OpenAI, Deepgram, and AssemblyAI through Context7, then cross-checked provider lifecycle documentation.
- Added unit coverage for buffer reuse, frame ordering, early stop, the memory limit, and cancellation.
- `./gradlew :lib:dictate-core:testDebugUnitTest`
- `./gradlew :lib:dictate-core:lintDebug`
- `./gradlew :app:testDebugUnitTest`
- `git diff --check`

## Protocol references

- [OpenAI realtime transcription](https://developers.openai.com/api/docs/guides/realtime-transcription)
- [Soniox WebSocket API](https://soniox.com/docs/api-reference/stt/websocket-api)
- [ElevenLabs realtime event reference](https://elevenlabs.io/docs/eleven-api/guides/how-to/speech-to-text/realtime/event-reference)
- [Deepgram live streaming](https://developers.deepgram.com/docs/getting-started-with-live-streaming-audio)
- [AssemblyAI Universal Streaming](https://www.assemblyai.com/docs/getting-started/transcribe-streaming-audio)
