### PR TITLE
Add GPT Live Transcribe support to realtime dictation

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/dictate/DictateProvidersScreen.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/settings/dictate/DictateProvidersScreen.kt
@@ -488,6 +488,8 @@ private fun ProviderEditorDialog(
     }
     var transcriptionModel by remember { mutableStateOf(account.transcriptionModel) }
     var chatModel by remember { mutableStateOf(account.chatModel) }
+    var realtimeModel by remember { mutableStateOf(account.realtimeModel) }
+    var showRealtimePicker by remember { mutableStateOf(false) }
     // Live catalog cache, updated when the picker fetches; persisted together with the rest on confirm.
     var cachedModels by remember { mutableStateOf(account.cachedModels) }
     var cachedAudioModels by remember { mutableStateOf(account.cachedAudioModels) }
@@ -539,6 +541,7 @@ private fun ProviderEditorDialog(
                     customBaseUrl = baseUrl.trim(),
                     transcriptionModel = transcriptionModel.trim(),
                     chatModel = chatModel.trim(),
+                    realtimeModel = realtimeModel.trim(),
                     cachedModels = cachedModels,
                     cachedAudioModels = cachedAudioModels,
                     cachedTranscriptionModels = cachedTranscriptionModels,
@@ -602,8 +605,22 @@ private fun ProviderEditorDialog(
                         ?: stringRes(R.string.dictate__model_placeholder),
                     onBrowse = { pickerKind = ModelKind.TRANSCRIPTION },
                 )
-                // Real-time streaming model (issue #128) is intentionally not exposed: every provider has
-                // effectively one usable streaming model, so the engine always uses the preset default.
+                // Streaming models use a different endpoint/protocol from normal STT models. Keep the
+                // field separate so provider defaults can evolve without overloading the batch picker.
+                if (preset?.supportsRealtime == true) {
+                    EditorField(
+                        label = stringRes(R.string.dictate__providers_field_realtime_model),
+                        value = realtimeModel,
+                        onValueChange = { realtimeModel = it },
+                        placeholder = preset.defaultRealtimeModel
+                            ?: stringRes(R.string.dictate__model_placeholder),
+                        onBrowse = if (preset.curatedRealtimeModels.isNotEmpty()) {
+                            { showRealtimePicker = true }
+                        } else {
+                            null
+                        },
+                    )
+                }
             }
             // Rewording model is unused while single-call multimodal is on (one model does both, #130).
             if (showChat && !transcriptionViaChat) {
@@ -674,6 +691,69 @@ private fun ProviderEditorDialog(
             },
             onDismiss = { pickerKind = null },
         )
+    }
+
+    if (showRealtimePicker && preset != null) {
+        RealtimeModelPickerDialog(
+            models = preset.curatedRealtimeModels,
+            default = preset.defaultRealtimeModel,
+            current = realtimeModel,
+            onPick = { realtimeModel = it },
+            onDismiss = { showRealtimePicker = false },
+        )
+    }
+}
+
+/**
+ * Picker for a provider's curated realtime models. An empty stored value follows the preset default,
+ * so an app update can migrate users who have not explicitly pinned an older model.
+ */
+@Composable
+private fun RealtimeModelPickerDialog(
+    models: List<String>,
+    default: String?,
+    current: String,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    JetPrefAlertDialog(
+        title = stringRes(R.string.dictate__providers_field_realtime_model),
+        dismissLabel = stringRes(R.string.action__cancel),
+        onDismiss = onDismiss,
+    ) {
+        Column {
+            models.forEach { model ->
+                val isDefault = model == default
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onPick(if (isDefault) "" else model)
+                            onDismiss()
+                        }
+                        .padding(vertical = 12.dp, horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                        selected = current == model || (current.isBlank() && isDefault),
+                        onClick = {
+                            onPick(if (isDefault) "" else model)
+                            onDismiss()
+                        },
+                    )
+                    Column(modifier = Modifier.padding(start = 8.dp)) {
+                        Text(model, style = MaterialTheme.typography.bodyLarge)
+                        if (isDefault) {
+                            Text(
+                                stringRes(R.string.dictate__providers_realtime_model_default),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/DictateController.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/dictate/DictateController.kt
@@ -56,6 +56,7 @@ import dev.patrickgold.florisboard.dictate.provider.OpenAiCompatibleClient
 import dev.patrickgold.florisboard.dictate.provider.RealtimeApi
 import dev.patrickgold.florisboard.dictate.provider.RealtimeCallbacks
 import dev.patrickgold.florisboard.dictate.provider.RealtimeClient
+import dev.patrickgold.florisboard.dictate.provider.RealtimeRequest
 import dev.patrickgold.florisboard.dictate.provider.RealtimeSession
 import dev.patrickgold.florisboard.dictate.provider.ProviderAccount
 import dev.patrickgold.florisboard.dictate.provider.ProviderPreset
@@ -1343,6 +1344,20 @@ object DictateController {
         val preset = presetFor(account)
         val model = account.realtimeModel.takeIf { it.isNotBlank() } ?: preset.defaultRealtimeModel ?: return null
         val language = prefs.dictate.activeInputLanguage.get().takeIf { it != DictateLanguages.DETECT }
+        val expectedLanguages = if (language != null) {
+            listOf(language)
+        } else {
+            DictateLanguages.parseSelection(prefs.dictate.inputLanguages.get())
+                .map { it.code }
+                .filter { it != DictateLanguages.DETECT }
+        }
+        val request = RealtimeRequest(
+            model = model,
+            language = language,
+            languages = expectedLanguages,
+            prompt = transcriptionStyleBasePrompt(),
+            keywords = transcriptionKeywords(),
+        )
         realtimeFinal.setLength(0)
         realtimeFailed = false
         realtimeCancelled = false
@@ -1379,7 +1394,7 @@ object DictateController {
             override fun onError(t: Throwable) { realtimeFailed = true }
             override fun onClosed() { closed.complete(Unit) }
         }
-        val session = runCatching { RealtimeClient.open(api, account.apiKey, model, language, callbacks) }
+        val session = runCatching { RealtimeClient.open(api, account.apiKey, request, callbacks) }
             .getOrElse { realtimeFailed = true; null } ?: return null
         realtimeSession = session
         val targetRate = RealtimeClient.sampleRateFor(api)
@@ -2677,6 +2692,14 @@ object DictateController {
      */
     private fun transcriptionStylePrompt(): String? =
         DictatePromptDefaults.appendCustomWords(transcriptionStyleBasePrompt(), prefs.dictate.customWords.get())
+
+    /** Custom vocabulary as literal realtime keyword hints; wire-level validation happens in the client. */
+    private fun transcriptionKeywords(): List<String> =
+        prefs.dictate.customWords.get()
+            .split(',', '\n')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
 
     /**
      * The style prompt WITHOUT the appended custom-words glossary — the predefined per-language sentence or

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1672,6 +1672,8 @@
 
     <string name="dictate__realtime_title" comment="Setting: real-time streaming transcription">Real-time transcription</string>
     <string name="dictate__realtime_summary" comment="Summary for the real-time transcription setting">Show text live while you speak, for providers that support it</string>
+    <string name="dictate__providers_field_realtime_model" comment="Label for the real-time streaming model picker">Real-time model</string>
+    <string name="dictate__providers_realtime_model_default" comment="Marks the provider's default real-time model in the picker">Default</string>
     <string name="dictate__longform_title" comment="Setting: long-form segmented dictation">Long-form dictation</string>
     <string name="dictate__longform_summary" comment="Summary for the long-form dictation setting">Transcribe long dictations in the background, part by part while you keep talking — tap Next during recording to send the current part, so there is no long wait at the end.</string>
     <string name="dictate__longform_autosplit_title" comment="Setting: use Silero VAD and Smart Turn to auto-cut a long-form segment">Smart auto-split</string>

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderRegistry.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/ProviderRegistry.kt
@@ -80,15 +80,17 @@ object ProviderRegistry {
             "gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1", "gpt-4.1-nano",
         ),
         curatedTranscriptionModels = listOf(
-            "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "whisper-1",
+            "gpt-transcribe", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "whisper-1",
         ),
-        // Realtime (#128): wss /v1/realtime?intent=transcription. gpt-realtime-whisper is the natively
-        // streaming model (emits deltas); the -transcribe models are more accurate but final-only.
+        // Realtime (#128): wss /v1/realtime?intent=transcription. GPT Live Transcribe is OpenAI's
+        // recommended continuously streaming model; keep the previous models available for accounts
+        // that explicitly selected them.
         supportsRealtime = true,
         realtimeApi = RealtimeApi.OPENAI,
-        defaultRealtimeModel = "gpt-realtime-whisper",
+        defaultRealtimeModel = "gpt-live-transcribe",
         curatedRealtimeModels = listOf(
-            "gpt-realtime-whisper", "gpt-4o-transcribe", "gpt-4o-mini-transcribe",
+            "gpt-live-transcribe", "gpt-transcribe", "gpt-realtime-whisper",
+            "gpt-4o-transcribe", "gpt-4o-mini-transcribe",
         ),
     )
 

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeClient.kt
@@ -12,6 +12,7 @@ package dev.patrickgold.florisboard.dictate.provider
 
 import android.util.Base64
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
@@ -59,24 +60,96 @@ object RealtimeClient {
     }
 
     /**
-     * Opens a session for [api] and starts connecting. [apiKey]/[model]/[language] identify the provider
-     * call; [callbacks] deliver interim/final text (on background threads). The returned [RealtimeSession]
-     * is fed PCM at [sampleRateFor] and finished/cancelled by the caller.
+     * Opens a session for [api] and starts connecting. [apiKey]/[request] identify the provider call;
+     * [callbacks] deliver interim/final text (on background threads). The returned [RealtimeSession] is
+     * fed PCM at [sampleRateFor] and finished/cancelled by the caller.
      */
     fun open(
         api: RealtimeApi,
         apiKey: String,
-        model: String,
-        language: String?,
+        request: RealtimeRequest,
         callbacks: RealtimeCallbacks,
     ): RealtimeSession = when (api) {
-        RealtimeApi.OPENAI -> OpenAiRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.DEEPGRAM -> DeepgramRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.SONIOX -> SonioxRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.ASSEMBLYAI -> AssemblyAiRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.ELEVENLABS -> ElevenLabsRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.GEMINI -> GeminiRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
-        RealtimeApi.MISTRAL_VOXTRAL -> MistralRealtimeSession(wsClient, apiKey, model, language, callbacks).also { it.connect() }
+        RealtimeApi.OPENAI ->
+            OpenAiRealtimeSession(wsClient, apiKey, request, callbacks).also { it.connect() }
+        RealtimeApi.DEEPGRAM ->
+            DeepgramRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+        RealtimeApi.SONIOX ->
+            SonioxRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+        RealtimeApi.ASSEMBLYAI ->
+            AssemblyAiRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+        RealtimeApi.ELEVENLABS ->
+            ElevenLabsRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+        RealtimeApi.GEMINI ->
+            GeminiRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+        RealtimeApi.MISTRAL_VOXTRAL ->
+            MistralRealtimeSession(wsClient, apiKey, request.model, request.language, callbacks).also { it.connect() }
+    }
+}
+
+/**
+ * Builds OpenAI's GA transcription-session update. The current GPT Transcribe family accepts
+ * multilingual [RealtimeRequest.languages] plus prompt/keyword context, while older realtime models
+ * still use the singular [RealtimeRequest.language] hint. The two shapes must not be mixed.
+ *
+ * Turn detection is disabled because Dictate explicitly commits once when the user stops recording.
+ */
+internal fun buildOpenAiRealtimeSessionUpdate(request: RealtimeRequest): String {
+    val modernTranscribe = request.model == "gpt-live-transcribe" ||
+        request.model.startsWith("gpt-live-transcribe-") ||
+        request.model == "gpt-transcribe" ||
+        request.model.startsWith("gpt-transcribe-")
+    val expectedLanguages = (request.languages + listOfNotNull(request.language))
+        .mapNotNull(::normalizeOpenAiRealtimeLanguage)
+        .distinct()
+    val safeKeywords = request.keywords
+        .map { it.trim() }
+        .filter {
+            it.isNotEmpty() && '<' !in it && '>' !in it && '\r' !in it && '\n' !in it
+        }
+        .distinct()
+    val delay = request.delay?.trim()?.lowercase()
+        ?.takeIf { it in setOf("minimal", "low", "medium", "high", "xhigh") }
+
+    return buildJsonObject {
+        put("type", "session.update")
+        put("session", buildJsonObject {
+            put("type", "transcription")
+            put("audio", buildJsonObject {
+                put("input", buildJsonObject {
+                    put("format", buildJsonObject {
+                        put("type", "audio/pcm")
+                        put("rate", 24_000)
+                    })
+                    put("transcription", buildJsonObject {
+                        put("model", request.model)
+                        if (modernTranscribe) {
+                            request.prompt?.trim()?.takeIf { it.isNotEmpty() }?.let { put("prompt", it) }
+                            if (safeKeywords.isNotEmpty()) {
+                                put("keywords", buildJsonArray { safeKeywords.forEach(::add) })
+                            }
+                            if (expectedLanguages.isNotEmpty()) {
+                                put("languages", buildJsonArray { expectedLanguages.forEach(::add) })
+                            }
+                            delay?.let { put("delay", it) }
+                        } else {
+                            request.language?.takeIf { it.isNotBlank() && it != "detect" }
+                                ?.let { put("language", it) }
+                        }
+                    })
+                    put("turn_detection", JsonNull)
+                })
+            })
+        })
+    }.toString()
+}
+
+private fun normalizeOpenAiRealtimeLanguage(raw: String): String? {
+    val language = raw.trim().lowercase().takeIf { it.isNotEmpty() && it != "detect" } ?: return null
+    return when {
+        language == "yue" || language.startsWith("yue-") -> "yue"
+        language.startsWith("zh-") -> language
+        else -> language.substringBefore('-')
     }
 }
 
@@ -84,14 +157,13 @@ object RealtimeClient {
  * OpenAI realtime transcription over `wss://api.openai.com/v1/realtime?intent=transcription`. Sends a
  * `session.update` transcription config on open, streams 24 kHz mono PCM16 as base64
  * `input_audio_buffer.append`, and turns `...input_audio_transcription.delta`/`.completed` events into
- * [RealtimeCallbacks.onPartial]/[onFinalSegment]. Model `gpt-realtime-whisper` streams deltas; the
- * `-transcribe` models only emit the final.
+ * [RealtimeCallbacks.onPartial]/[onFinalSegment]. `gpt-live-transcribe` streams low-latency deltas;
+ * `gpt-transcribe` starts after a committed turn and can also return detected languages.
  */
 private class OpenAiRealtimeSession(
     private val client: OkHttpClient,
     private val apiKey: String,
-    private val model: String,
-    private val language: String?,
+    private val request: RealtimeRequest,
     private val callbacks: RealtimeCallbacks,
 ) : RealtimeSession {
 
@@ -118,7 +190,7 @@ private class OpenAiRealtimeSession(
 
     private val listener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
-            webSocket.send(sessionUpdate())
+            webSocket.send(buildOpenAiRealtimeSessionUpdate(request))
             // OkHttp accepts send() calls while a socket is still connecting. Without this gate, mic
             // frames queued during the handshake precede this session.update and therefore arrive before
             // OpenAI knows the intended PCM format/model. Put the config first, then replay the beginning.
@@ -154,25 +226,6 @@ private class OpenAiRealtimeSession(
         }
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) = finishClosed(webSocket)
     }
-
-    private fun sessionUpdate(): String = buildJsonObject {
-        put("type", "session.update")
-        put("session", buildJsonObject {
-            put("type", "transcription")
-            put("audio", buildJsonObject {
-                put("input", buildJsonObject {
-                    put("format", buildJsonObject {
-                        put("type", "audio/pcm")
-                        put("rate", 24_000)
-                    })
-                    put("transcription", buildJsonObject {
-                        put("model", model)
-                        if (!language.isNullOrBlank() && language != "detect") put("language", language)
-                    })
-                })
-            })
-        })
-    }.toString()
 
     override fun sendAudio(pcm16: ByteArray, len: Int) {
         audioGate.sendAudio(pcm16, len) { audio, length ->

--- a/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeTranscription.kt
+++ b/lib/dictate-core/src/main/kotlin/dev/patrickgold/florisboard/dictate/provider/RealtimeTranscription.kt
@@ -51,6 +51,17 @@ data class RealtimeRequest(
     val model: String,
     /** ISO language code, or null/"detect" for auto-detect. */
     val language: String? = null,
+    /**
+     * Expected input languages for models that support multilingual hints. OpenAI's
+     * `gpt-live-transcribe` and `gpt-transcribe` use this plural field instead of [language].
+     */
+    val languages: List<String> = emptyList(),
+    /** Free-form context about the recording or setting, when supported by the provider/model. */
+    val prompt: String? = null,
+    /** Literal names, acronyms and jargon that may occur in the audio. */
+    val keywords: List<String> = emptyList(),
+    /** Optional provider-specific latency/accuracy preset (for example `low` or `medium`). */
+    val delay: String? = null,
     /** Sample rate (Hz) of the mono 16-bit little-endian PCM the caller will send. */
     val sampleRate: Int = 16_000,
 )

--- a/lib/dictate-core/src/test/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiRealtimeSessionTest.kt
+++ b/lib/dictate-core/src/test/kotlin/dev/patrickgold/florisboard/dictate/provider/OpenAiRealtimeSessionTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.dictate.provider
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class OpenAiRealtimeSessionTest {
+
+    @Test
+    fun liveTranscribeUsesCurrentMultilingualSessionShape() {
+        val payload = buildOpenAiRealtimeSessionUpdate(
+            RealtimeRequest(
+                model = "gpt-live-transcribe",
+                languages = listOf("en", "yue-HK", "zh-TW", "en-US"),
+                prompt = "  A multilingual meeting.  ",
+                keywords = listOf("ASD", "JUPAS", "ASD", "bad<keyword", "two\nlines"),
+                delay = " MEDIUM ",
+            )
+        )
+
+        val input = Json.parseToJsonElement(payload).jsonObject["session"]!!.jsonObject["audio"]!!
+            .jsonObject["input"]!!.jsonObject
+        val format = input["format"]!!.jsonObject
+        val transcription = input["transcription"]!!.jsonObject
+
+        assertEquals("audio/pcm", format["type"]!!.jsonPrimitive.content)
+        assertEquals(24_000, format["rate"]!!.jsonPrimitive.content.toInt())
+        assertEquals(JsonNull, input["turn_detection"])
+        assertEquals("gpt-live-transcribe", transcription["model"]!!.jsonPrimitive.content)
+        assertEquals("A multilingual meeting.", transcription["prompt"]!!.jsonPrimitive.content)
+        assertEquals(
+            listOf("ASD", "JUPAS"),
+            transcription["keywords"]!!.jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals(
+            listOf("en", "yue", "zh-tw"),
+            transcription["languages"]!!.jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals("medium", transcription["delay"]!!.jsonPrimitive.content)
+        assertFalse("language" in transcription)
+    }
+
+    @Test
+    fun legacyRealtimeModelKeepsSingularLanguageShape() {
+        val payload = buildOpenAiRealtimeSessionUpdate(
+            RealtimeRequest(
+                model = "gpt-realtime-whisper",
+                language = "yue-HK",
+                languages = listOf("en", "zh-TW"),
+                prompt = "Ignored by the legacy shape",
+                keywords = listOf("Ignored"),
+                delay = "low",
+            )
+        )
+
+        val input = Json.parseToJsonElement(payload).jsonObject["session"]!!.jsonObject["audio"]!!
+            .jsonObject["input"]!!.jsonObject
+        val transcription = input["transcription"]!!.jsonObject
+
+        assertEquals(JsonNull, input["turn_detection"])
+        assertEquals("gpt-realtime-whisper", transcription["model"]!!.jsonPrimitive.content)
+        assertEquals("yue-HK", transcription["language"]!!.jsonPrimitive.content)
+        assertFalse("languages" in transcription)
+        assertFalse("prompt" in transcription)
+        assertFalse("keywords" in transcription)
+        assertFalse("delay" in transcription)
+    }
+
+    @Test
+    fun openAiDefaultsToRecommendedLiveTranscriptionModel() {
+        assertEquals("gpt-live-transcribe", ProviderRegistry.OPENAI.defaultRealtimeModel)
+        assertEquals(true, "gpt-transcribe" in ProviderRegistry.OPENAI.curatedTranscriptionModels)
+        assertEquals(
+            "gpt-live-transcribe",
+            ProviderRegistry.OPENAI.curatedRealtimeModels.first(),
+        )
+        assertEquals(true, "gpt-realtime-whisper" in ProviderRegistry.OPENAI.curatedRealtimeModels)
+    }
+}


### PR DESCRIPTION
## What changed

- Use `gpt-live-transcribe` as the default OpenAI realtime model while retaining the legacy realtime and GPT-4o transcription models as explicit compatibility choices.
- Add `gpt-transcribe` to the normal speech-to-text picker.
- Build the current GA transcription-session payload for GPT Transcribe models: 24 kHz PCM, `turn_detection: null`, multilingual `languages`, style `prompt`, safe custom-vocabulary `keywords`, and optional `delay`.
- Preserve the singular `language` payload for legacy OpenAI realtime models.
- Restore the separate per-provider realtime model selector so the realtime WebSocket model is no longer hidden behind the normal batch model field.
- Add payload regression tests for both the current and legacy OpenAI session shapes.

## Why

The realtime toggle already opens the OpenAI Realtime WebSocket, but the app still defaults to the legacy hidden `gpt-realtime-whisper` model. Entering `gpt-live-transcribe` in the normal transcription field does not affect that path and can route the model to an incompatible endpoint instead.

This patch keeps batch transcription, chat-audio, and realtime transcription as separate model roles, and follows the current OpenAI Realtime transcription protocol. It also lets multilingual users pass the selected expected languages and existing style/vocabulary context without mixing the new plural `languages` field with the legacy singular field.

Official protocol reference: https://developers.openai.com/api/docs/guides/realtime-transcription

## Validation

- `./gradlew :lib:dictate-core:test`
- `./gradlew :app:testDebugUnitTest --max-workers=1` with a temporary 1536 MB test-worker heap because the default worker ran out of memory
- `./gradlew :app:assembleDebug --max-workers=1`
- Kotlin compilation and `git diff --check`

`lintDebug` still reports the existing upstream lint backlog (65 errors and 632 warnings); the report did not identify a new issue in the Realtime payload code. A live OpenAI API-key test is intentionally not included in the automated suite.