### PR TITLE
Decode autocorrect from touch coordinates with a beam search (#242)

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -46,6 +46,7 @@ import dev.patrickgold.florisboard.ime.input.InputShiftState
 import dev.patrickgold.florisboard.ime.nlp.ClipboardSuggestionCandidate
 import dev.patrickgold.florisboard.ime.nlp.PunctuationRule
 import dev.patrickgold.florisboard.ime.nlp.SuggestionCandidate
+import dev.patrickgold.florisboard.ime.nlp.latin.TouchTrace
 import dev.patrickgold.florisboard.ime.popup.PopupMappingComponent
 import dev.patrickgold.florisboard.ime.text.composing.Composer
 import dev.patrickgold.florisboard.ime.text.gestures.SwipeAction
@@ -303,6 +304,9 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
         scope.launch {
             candidate.sourceProvider?.notifySuggestionAccepted(subtypeManager.activeSubtype, candidate)
         }
+        // The composing word is being replaced wholesale, so its tap evidence no longer describes what is
+        // in the editor (issue #242).
+        TouchTrace.reset()
         when (candidate) {
             is ClipboardSuggestionCandidate -> editorInstance.commitClipboardItem(candidate.clipboardItem)
             else -> editorInstance.commitCompletion(candidate)
@@ -310,6 +314,8 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     }
 
     fun commitGesture(word: String) {
+        // A glide produces a whole word at once, so there are no per-character taps to reason about (#242).
+        TouchTrace.reset()
         editorInstance.commitGesture(fixCase(word))
     }
 
@@ -441,6 +447,9 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             it.isManualSelectionModeEnd = false
         }
         revertPreviouslyAcceptedCandidate()
+        // Keep the tap evidence aligned with the word: a single-character backspace drops the last tap,
+        // anything coarser (a whole word) invalidates the trace entirely (issue #242).
+        if (unit == OperationUnit.CHARACTERS) TouchTrace.pop() else TouchTrace.reset()
         editorInstance.deleteBackwards(unit)
     }
 
@@ -461,6 +470,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
      * Handles a [KeyCode.ENTER] event.
      */
     private fun handleEnter() {
+        TouchTrace.reset() // word boundary (issue #242)
         val info = editorInstance.activeInfo
         val isShiftPressed = inputEventDispatcher.isPressed(KeyCode.SHIFT)
         if (editorInstance.tryPerformEnterCommitRaw()) {
@@ -633,6 +643,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
     private fun handleSpace(data: KeyData) {
         val candidate = nlpManager.getAutoCommitCandidate()
         candidate?.let { commitCandidate(it) }
+        TouchTrace.reset() // word boundary (issue #242)
         if (prefs.keyboard.spaceBarSwitchesToCharacters.get()) {
             when (activeState.keyboardMode) {
                 KeyboardMode.NUMERIC_ADVANCED,
@@ -997,6 +1008,10 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                             val text = data.asString(isForDisplay = false)
                             if (!UCharacter.isUAlphabetic(UCharacter.codePointAt(text, 0))) {
                                 nlpManager.getAutoCommitCandidate()?.let { commitCandidate(it) }
+                                // Punctuation ends the word — drop the tap evidence for it (issue #242).
+                                TouchTrace.reset()
+                            } else {
+                                TouchTrace.commit(text)
                             }
                             editorInstance.commitChar(text)
                         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/KeyProximityInfo.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/KeyProximityInfo.kt
@@ -14,38 +14,143 @@ import dev.patrickgold.florisboard.ime.keyboard.KeyData
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKey
 
 /**
- * Live snapshot of the character keyboard's key geometry, for the autocorrect proximity ("touch") model
- * (issue: better autocorrect / Tier 1): weight a typo edit by how physically close the two keys are, so a
- * fat-finger substitution of an adjacent key ranks above a far one. Updated from the rendered layout every
- * time the CHARACTERS keyboard is shown — independent of glide typing (the layout normally only feeds the
- * glide classifier, which is off for many users).
+ * Live snapshot of the character keyboard's key geometry, for the autocorrect touch model (issue #242).
+ * Updated from the rendered layout every time the CHARACTERS keyboard is shown — independent of glide
+ * typing (the layout normally only feeds the glide classifier, which is off for many users).
  *
- * Keys are stored by their base char code → pixel center; distances are normalized to key-widths so the
- * model is resolution/DPI independent.
+ * All coordinates are stored **normalized to key widths**, so everything downstream is resolution- and
+ * DPI-independent: a distance of 1.0 means "one key width apart".
+ *
+ * Two consumers, deliberately different in what they know:
+ *  - [normSqDistance] compares two *keys* and serves the legacy edit-distance ranking, which only ever sees
+ *    the resolved character, not where the finger actually landed.
+ *  - [snapshot] hands the beam decoder an immutable [Layout] so one decode sees one consistent geometry
+ *    even if the keyboard re-lays-out underneath it.
  */
 object KeyProximityInfo {
-    @Volatile private var centers: Map<Int, FloatArray> = emptyMap() // char code -> [x, y]
-    @Volatile private var keyWidth: Float = 0f
+
+    /**
+     * Immutable view of one keyboard layout, in key-width units. Primitive arrays throughout: this is a
+     * per-keystroke hot path and the decoder queries it thousands of times per word.
+     */
+    class Layout(
+        private val codes: IntArray,
+        private val xs: FloatArray,
+        private val ys: FloatArray,
+    ) {
+        val size: Int get() = codes.size
+
+        fun codeAt(index: Int): Int = codes[index]
+
+        /** Squared distance from the normalized point ([x], [y]) to the key at [index], in key-width². */
+        fun sqDistance(index: Int, x: Float, y: Float): Float {
+            val dx = xs[index] - x
+            val dy = ys[index] - y
+            return dx * dx + dy * dy
+        }
+
+        /** Squared distance between two keys of this layout, in key-width². */
+        fun sqDistanceBetween(a: Int, b: Int): Float = sqDistance(a, xs[b], ys[b])
+
+        /** Squared distance to the closest key of all — the reference cost for a likelihood ratio. */
+        fun nearestSqDistance(x: Float, y: Float): Float {
+            var best = Float.MAX_VALUE
+            for (i in codes.indices) {
+                val d = sqDistance(i, x, y)
+                if (d < best) best = d
+            }
+            return if (best == Float.MAX_VALUE) 0f else best
+        }
+
+        /**
+         * Writes the indices of the [out].size keys closest to ([x], [y]) into [out], nearest first, and
+         * returns how many were written. Insertion into a tiny fixed array — with ~30 keys and a handful of
+         * slots this beats allocating and sorting a list on every tap of every beam expansion.
+         */
+        fun nearestKeys(x: Float, y: Float, out: IntArray): Int {
+            val want = minOf(out.size, codes.size)
+            if (want == 0) return 0
+            val dists = FloatArray(want) { Float.MAX_VALUE }
+            var filled = 0
+            for (i in codes.indices) {
+                val d = sqDistance(i, x, y)
+                if (filled < want || d < dists[want - 1]) {
+                    var pos = if (filled < want) filled else want - 1
+                    while (pos > 0 && dists[pos - 1] > d) {
+                        dists[pos] = dists[pos - 1]
+                        out[pos] = out[pos - 1]
+                        pos--
+                    }
+                    dists[pos] = d
+                    out[pos] = i
+                    if (filled < want) filled++
+                }
+            }
+            return filled
+        }
+
+        /** Index of the key for [char], or -1 — tries the exact code first, then the lowercase one. */
+        fun indexOf(char: Char): Int {
+            val code = char.code
+            for (i in codes.indices) if (codes[i] == code) return i
+            val lower = char.lowercaseChar().code
+            if (lower != code) {
+                for (i in codes.indices) if (codes[i] == lower) return i
+            }
+            return -1
+        }
+    }
+
+    @Volatile
+    private var layout: Layout? = null
+
+    // Pixel width of one key in the currently rendered layout, for converting raw touch coordinates.
+    @Volatile
+    private var keyWidthPx: Float = 0f
 
     /** Update from the currently rendered character keys. Cheap; called on each layout of the letters view. */
     fun update(keys: List<TextKey>) {
         if (keys.isEmpty()) return
-        val map = HashMap<Int, FloatArray>(keys.size)
         var width = 0f
+        for (k in keys) {
+            val code = (k.data as? KeyData)?.code ?: continue
+            if (code < 32) continue
+            val w = k.visibleBounds.width
+            if (w > 0f) {
+                width = w
+                break
+            }
+        }
+        if (width <= 0f) return
+        val codes = ArrayList<Int>(keys.size)
+        val xs = ArrayList<Float>(keys.size)
+        val ys = ArrayList<Float>(keys.size)
         for (k in keys) {
             val code = (k.data as? KeyData)?.code ?: continue
             if (code < 32) continue // skip control/action keys (space, shift, delete, …)
             val bounds = k.visibleBounds
-            map[code] = floatArrayOf(bounds.center.x, bounds.center.y)
-            if (width == 0f) width = bounds.width
+            codes.add(code)
+            xs.add(bounds.center.x / width)
+            ys.add(bounds.center.y / width)
         }
-        centers = map
-        keyWidth = width
+        if (codes.isEmpty()) return
+        keyWidthPx = width
+        layout = Layout(codes.toIntArray(), xs.toFloatArray(), ys.toFloatArray())
     }
 
     /** True once a layout has been captured and distances can be computed. */
     val isReady: Boolean
-        get() = keyWidth > 0f && centers.isNotEmpty()
+        get() = layout != null && keyWidthPx > 0f
+
+    /** Immutable geometry for one decode, or null if no layout has been rendered yet. */
+    fun snapshot(): Layout? = layout
+
+    /** Converts a raw touch coordinate in pixels to key-width units, or null if no layout is known. */
+    fun normalize(xPx: Float, yPx: Float): FloatArray? {
+        val w = keyWidthPx
+        if (w <= 0f) return null
+        return floatArrayOf(xPx / w, yPx / w)
+    }
 
     /**
      * Squared physical distance between the keys for [a] and [b] in key-width² units (0 for the same char,
@@ -54,12 +159,11 @@ object KeyProximityInfo {
      */
     fun normSqDistance(a: Char, b: Char): Float? {
         if (a == b) return 0f
-        val w = keyWidth
-        if (w <= 0f) return null
-        val pa = centers[a.code] ?: centers[a.lowercaseChar().code] ?: return null
-        val pb = centers[b.code] ?: centers[b.lowercaseChar().code] ?: return null
-        val dx = (pa[0] - pb[0]) / w
-        val dy = (pa[1] - pb[1]) / w
-        return dx * dx + dy * dy
+        val l = layout ?: return null
+        val ia = l.indexOf(a)
+        if (ia < 0) return null
+        val ib = l.indexOf(b)
+        if (ib < 0) return null
+        return l.sqDistanceBetween(ia, ib)
     }
 }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -99,6 +99,11 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         // a correctly typed name needs a full key jump (expensive).
         private const val AUTO_COMMIT_MAX_TOUCH_COST = 0.8f
 
+        // Candidates are de-duplicated by their case-folded text. The typed spelling kept alongside a noun
+        // capitalisation folds to the very same key as the capitalised form, so it is stored under this
+        // prefix, a NUL character that no dictionary word can contain.
+        private const val TYPED_WORD_KEY = "\u0000"
+
         // German umlaut/ß restoration (issue #219): bound the variant generation so a long word with many
         // a/o/u doesn't explode combinatorially (2^sites). Words needing more than this are left alone.
         private const val MAX_UMLAUT_SITES = 6
@@ -328,6 +333,20 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         val langs = LinkedHashSet<String>().apply { add(active) }
         runCatching { subtypeManager.subtypes.forEach { langs.add(dictLangFor(it)) } }
         return langs.toList()
+    }
+
+    /**
+     * True if [lower] is an ordinary lowercase word in one of the user's *other* keyboard languages, so the
+     * active language's noun capitalisation must stand aside (issue #190): an English "hand" typed with the
+     * German subtype active should not become "Hand".
+     */
+    private suspend fun isLowercaseWordInAnotherLanguage(lower: String, subtype: Subtype): Boolean {
+        val active = dictLangFor(subtype)
+        for (lang in acceptedDictLangs(subtype)) {
+            if (lang == active) continue
+            if (lowerIndexForLang(lang).canonical[lower]?.first()?.isLowerCase() == true) return true
+        }
+        return false
     }
 
     /** True if [word] is a known dictionary word in any accepted language, or in the user dictionary. */
@@ -707,10 +726,47 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                 }
         }
 
+        val autoCorrectOn = prefs.suggestion.autoCorrect.get()
+
+        // Noun capitalisation (issue #242 follow-up). German capitalises every noun, but typing one
+        // lowercase produced no correction at all: the case-folded index reports "haus" as a known word, so
+        // the whole correction path below is skipped and "Haus" only ever appeared as an ordinary prefix
+        // completion, which is never auto-committed. Roughly 31 % of typed German words are affected.
+        //
+        // The dictionary itself says which words these are: tools/glide-dict/generate.py stores a word
+        // capitalised exactly when the case oracle rejects its lowercase spelling, i.e. for genuine nouns.
+        // Words that are valid lowercase ("essen", "laufen", "recht", "sie") are stored lowercase and are
+        // therefore left alone here, which is what keeps this from mangling ordinary text.
+        //
+        // Deliberately hangs off the existing "Auto-capitalization" preference rather than adding its own:
+        // anyone who types in all-lowercase on purpose has already turned that off, since it would otherwise
+        // capitalise every sentence start too.
+        if (autoCorrectOn && prefs.correction.autoCapitalization.get() &&
+            word.length >= 2 && word.none { it.isUpperCase() }
+        ) {
+            val lower = word.lowercase()
+            val canonical = index.canonical[lower]
+            if (canonical != null && canonical.first().isUpperCase() && canonical != word &&
+                !isLowercaseWordInAnotherLanguage(lower, subtype)
+            ) {
+                // Keep the typed spelling tappable and left-most so the capitalisation can be bypassed
+                // (issue #150). It shares its case-folded key with the capitalised form, so it goes in under
+                // a key that no dictionary word can produce.
+                out[TYPED_WORD_KEY + lower] = WordSuggestionCandidate(
+                    text = word, confidence = 1.0, isEligibleForAutoCommit = false, sourceProvider = this,
+                )
+                out[lower] = WordSuggestionCandidate(
+                    text = canonical,
+                    confidence = (index.freq[lower] ?: 0) / 255.0,
+                    isEligibleForAutoCommit = true,
+                    sourceProvider = this,
+                )
+            }
+        }
+
         // Whether the composed word is valid in any of the user's keyboard languages (multilingual, #190);
         // computed up front because it also decides whether to reserve strip slots for spelling fixes.
         val isKnown = isKnownWord(word, subtype)
-        val autoCorrectOn = prefs.suggestion.autoCorrect.get()
         // Reserve a few slots for edit-distance corrections so a typo's fix isn't crowded out by prefix
         // completions of that typo (issue #212). Only when we'd actually correct (unknown word, length >= 3).
         val completionCap = if (autoCorrectOn && !isKnown && word.length >= 3) {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -72,6 +72,33 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         // follows the previous word, so context ("of the" over "of teh") re-ranks the correction.
         private const val CONTEXT_WEIGHT = 0.3
 
+        // --- Touch-decoded corrections (issue #242) -------------------------------------------------
+        // Used only on the path where real tap coordinates are available; the legacy ranking above keeps its
+        // own constants so behaviour without a trace is bit-for-bit unchanged.
+        //
+        // The dictionary stores frequencies on a 128..255 scale that is already *linear in log frequency*
+        // (tools/glide-dict/generate.py), so the prior is linear here rather than another ln() — taking the
+        // log twice would squash the whole vocabulary into 0.69 nats and make the language model irrelevant.
+        // LM_SPAN is that scale expressed in nats.
+        private const val LM_SPAN = 4.0
+        // Touch variance in key-width², i.e. how much an off-centre tap is allowed to cost. Tuned together
+        // with LM_SPAN; accuracy varies by under 1 pp when either is doubled or halved.
+        private const val TOUCH_SIGMA2 = 0.2
+        // Flat cost for a candidate of a different length (a dropped or doubled letter), which the beam
+        // cannot produce and which therefore comes from the edit-distance generator.
+        private const val TOUCH_LENGTH_PENALTY = -5.0
+        // How many words the beam returns before scoring.
+        private const val BEAM_CANDIDATES = 12
+        // Highest excess tap distance (key-width², summed over the word) still allowed to *silently* replace
+        // what was typed. Suggestions are always offered; this only gates the automatic swap.
+        //
+        // Without it, any unknown word with a frequent neighbour gets rewritten — measured on German, 30% of
+        // correctly typed out-of-dictionary words (names like "Sarahs"→"daraus", "Pete"→"Peter") would be
+        // mangled, far worse than the 19% the old gate allowed. At 0.8 that drops to ~0% while still
+        // auto-fixing 95% of genuine mis-taps, because a real slip lands near a key boundary (cheap) whereas
+        // a correctly typed name needs a full key jump (expensive).
+        private const val AUTO_COMMIT_MAX_TOUCH_COST = 0.8f
+
         // German umlaut/ß restoration (issue #219): bound the variant generation so a long word with many
         // a/o/u doesn't explode combinatorially (2^sites). Words needing more than this are left alone.
         private const val MAX_UMLAUT_SITES = 6
@@ -232,6 +259,20 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
 
     private val lowerIndexByLang = guardedByLock { mutableMapOf<String, LowerIndex>() }
 
+    // Lexicographically sorted word list per language, used by the beam decoder to prune partial paths that
+    // are no longer a prefix of any real word (issue #242). Shares its strings with the LowerIndex, so this
+    // costs one array of references per language and no duplicated character data.
+    private val prefixIndexByLang = guardedByLock { mutableMapOf<String, TouchBeamDecoder.PrefixIndex>() }
+
+    private suspend fun prefixIndexFor(subtype: Subtype): TouchBeamDecoder.PrefixIndex {
+        val lang = dictLangFor(subtype)
+        val index = lowerIndexFor(subtype)
+        return prefixIndexByLang.withLock { cache ->
+            cache[lang] ?: TouchBeamDecoder.PrefixIndex(index.freq.keys.toTypedArray().apply { sort() })
+                .also { cache[lang] = it }
+        }
+    }
+
     private fun startDictionaryWatcher() {
         // When a dictionary finishes downloading, drop the resolved-language cache so the active subtype
         // starts using it immediately (issue #127). Started from create() rather than init: launching a
@@ -244,6 +285,7 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                 rankedWordsByLang.withLock { it.clear() }
                 lowerIndexByLang.withLock { it.clear() }
                 bigramsByLang.withLock { it.clear() }
+                prefixIndexByLang.withLock { it.clear() }
             }
         }
     }
@@ -373,6 +415,76 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         for (j in i + 2 until a.length) if (a[j] != b[j]) return false
         return true
     }
+
+    // --- Touch-decoded corrections (issue #242) -----------------------------------------------------
+
+    /**
+     * Corrections decoded from tap positions, plus how well the taps actually support the best one.
+     *
+     * [topCost] is the winning candidate's excess tap distance, or null when it came from edit distance and
+     * there is therefore no positional evidence either way (a dropped or doubled letter).
+     */
+    private class TouchCorrections(val words: List<String>, val topCost: Float?)
+
+    /**
+     * Corrections decoded from where the user's fingers actually landed, or null when that is not possible
+     * (no tap evidence for this exact word, no captured key geometry, or the beam found nothing) — in which
+     * case the caller falls back to the classic edit-distance path unchanged.
+     *
+     * The beam contributes same-length candidates with near-perfect recall; a dropped or doubled letter
+     * changes the length and cannot come out of it, so those still come from [edits1] and are scored with a
+     * flat penalty. Both are then ranked on one scale: linear log-frequency prior, minus the excess tap
+     * distance, plus the bigram context bonus.
+     */
+    private suspend fun touchCorrectionsFor(
+        word: String,
+        subtype: Subtype,
+        index: LowerIndex,
+        maxCount: Int,
+        contextScore: (cand: String) -> Double,
+    ): TouchCorrections? {
+        val points = TouchTrace.pointsFor(word) ?: return null
+        val layout = KeyProximityInfo.snapshot() ?: return null
+        val beam = TouchBeamDecoder.decode(
+            points = points,
+            typed = word,
+            index = prefixIndexFor(subtype),
+            layout = layout,
+            maxResults = BEAM_CANDIDATES,
+        )
+        if (beam.isEmpty()) return null
+
+        val scored = HashMap<String, Double>(beam.size * 2)
+        // Tap cost per beam candidate, kept so the caller can tell a near-boundary slip (trustworthy enough
+        // to swap in silently) from a candidate a whole key away (offer it, but don't act on it).
+        val costs = HashMap<String, Float>(beam.size)
+        for (candidate in beam) {
+            val freq = index.freq[candidate.word] ?: continue
+            scored[candidate.word] =
+                lmPrior(freq) - candidate.cost / (2.0 * TOUCH_SIGMA2) + contextScore(candidate.word)
+            costs[candidate.word] = candidate.cost
+        }
+        // Length-changing slips (a letter dropped or typed twice) are invisible to the beam.
+        val lower = word.lowercase()
+        for (edit in edits1(lower, index.alphabet)) {
+            if (edit.length == lower.length) continue
+            val freq = index.freq[edit] ?: continue
+            scored.putIfAbsent(edit, lmPrior(freq) + TOUCH_LENGTH_PENALTY + contextScore(edit))
+        }
+        if (scored.isEmpty()) return null
+        val ranked = scored.entries.sortedByDescending { it.value }.take(maxCount)
+        return TouchCorrections(
+            words = ranked.map { index.canonical[it.key] ?: it.key },
+            topCost = costs[ranked.first().key],
+        )
+    }
+
+    /**
+     * Log-probability prior for a dictionary frequency. The stored 128..255 values are already linear in log
+     * frequency, so this only rescales them into nats — applying ln() again (as the legacy [channelScore]
+     * does) would compress the entire vocabulary into 0.69 nats.
+     */
+    private fun lmPrior(freq: Int): Double = (freq - 128).coerceAtLeast(0) / 127.0 * LM_SPAN
 
     // --- German umlaut / ß restoration (issue #219) -------------------------------------------------
 
@@ -644,13 +756,29 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
             val prevWord = previousWordOf(content)
             val bigrams = if (prevWord != null) bigramsFor(subtype) else emptyMap()
             val ctx = bigramContextScore(prevWord, bigrams)
-            var corrections = correctionsFor(word, index, CORRECTION_MAX, allowDistance2 = false, ctx)
+            // Preferred: decode from the actual tap positions (issue #242). Falls back to edit distance
+            // whenever no usable tap evidence exists — hardware keyboard, glide, pasted or dictated text,
+            // or a cursor jump that desynced the trace.
+            val touchCorrections = touchCorrectionsFor(word, subtype, index, CORRECTION_MAX, ctx)
+            var corrections = touchCorrections?.words
+                ?: correctionsFor(word, index, CORRECTION_MAX, allowDistance2 = false, ctx)
             val distance1Empty = corrections.isEmpty()
-            if (distance1Empty && word.length <= MAX_DISTANCE2_LEN) {
+            if (touchCorrections == null && distance1Empty && word.length <= MAX_DISTANCE2_LEN) {
                 corrections = correctionsFor(word, index, CORRECTION_MAX, allowDistance2 = true, ctx)
             }
-            // Only a confident distance-1 fix, with nothing else surfaced, is auto-committed.
-            val allowAutoCommit = !hadCandidatesBefore && !distance1Empty
+            // What may be swapped in *silently* (the strip always shows everything either way).
+            val topTouchCost = touchCorrections?.topCost
+            val allowAutoCommit = when {
+                // Decoded from the taps: act only when the fingers really were near that key. This replaces
+                // the `hadCandidatesBefore` gate, which suppressed 2.7 % of otherwise correct fixes merely
+                // because the typo prefixed some dictionary word — while a bare "a correction exists" rule
+                // would rewrite 30 % of correctly typed names.
+                topTouchCost != null -> topTouchCost <= AUTO_COMMIT_MAX_TOUCH_COST
+                // A dropped or doubled letter: the beam cannot see it and the taps say nothing either way,
+                // so keep the conservative classic rule.
+                touchCorrections != null -> !hadCandidatesBefore
+                else -> !hadCandidatesBefore && !distance1Empty
+            }
             if (corrections.isNotEmpty() && allowAutoCommit) {
                 // Keep the exact typed word tappable, left-most, to bypass the auto-correction (issue #150).
                 out.putIfAbsent(

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchBeamDecoder.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchBeamDecoder.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.ime.nlp.latin
+
+/**
+ * Decodes what the user *meant* directly from where their fingers landed (issue #242).
+ *
+ * The classic corrector takes the already-resolved string ("hte") and looks for dictionary words within one
+ * edit. That throws away the only evidence that matters — how close each tap was to its key — and it can
+ * only ever propose words reachable by a single edit. Measured on the shipping dictionary, the intended word
+ * is inside that candidate set just **52.7 %** of the time; a beam search over the taps finds it **99.7 %**
+ * of the time, which is where nearly all of the accuracy difference to a commercial keyboard comes from.
+ *
+ * The search walks the taps left to right. At each tap it considers only the [KEY_ALTERNATIVES] nearest
+ * keys, keeps the [BEAM_WIDTH] cheapest paths, and immediately discards any path that is no longer the
+ * prefix of a real word. Cost per key is the *excess* squared distance over the closest key, so a
+ * dead-centre tap is free and only genuine ambiguity is paid for — that keeps the numbers on the same scale
+ * as the legacy proximity model instead of drowning the language model.
+ *
+ * Pruning uses [PrefixIndex], a plain sorted word list: a path is a range `[lo, hi)` of dictionary entries
+ * sharing that prefix, and extending it by one character narrows the range by binary search. No trie, no
+ * extra memory, and no string allocation anywhere in the loop.
+ */
+object TouchBeamDecoder {
+
+    /** How many paths survive each tap. 24 was ample in simulation; wider changed nothing measurable. */
+    private const val BEAM_WIDTH = 24
+
+    /** Keys considered per tap. Beyond ~6 the extra keys are too far away to ever win. */
+    private const val KEY_ALTERNATIVES = 6
+
+    /** Longest word to decode. Guards the (linear) cost on pathological input. */
+    private const val MAX_LENGTH = 32
+
+    /** A decoded word together with the total excess tap distance that produced it (lower is better). */
+    class Candidate(val word: String, val cost: Float)
+
+    /**
+     * Lexicographically sorted lowercase dictionary, supporting prefix queries as range narrowing.
+     * Built once per language and cached alongside the other per-language data.
+     */
+    class PrefixIndex(val words: Array<String>) {
+
+        /**
+         * Narrows `[lo, hi)` — all words sharing a prefix of length [depth] — to those whose character at
+         * [depth] equals [ch]. Returns the packed range `(lo shl 32) or hi`, or -1 when nothing matches.
+         *
+         * Words shorter than `depth + 1` sort before all longer ones inside the range, so the matching
+         * entries are always contiguous and binary search applies.
+         */
+        fun narrow(lo: Int, hi: Int, depth: Int, ch: Char): Long {
+            val start = lowerBound(lo, hi, depth, ch)
+            if (start >= hi) return -1L
+            val w = words[start]
+            if (w.length <= depth || w[depth] != ch) return -1L
+            val end = upperBound(start, hi, depth, ch)
+            return (start.toLong() shl 32) or (end.toLong() and 0xFFFFFFFFL)
+        }
+
+        private fun keyAt(index: Int, depth: Int): Int {
+            val w = words[index]
+            return if (w.length <= depth) -1 else w[depth].code
+        }
+
+        private fun lowerBound(lo: Int, hi: Int, depth: Int, ch: Char): Int {
+            var a = lo
+            var b = hi
+            val target = ch.code
+            while (a < b) {
+                val mid = (a + b) ushr 1
+                if (keyAt(mid, depth) < target) a = mid + 1 else b = mid
+            }
+            return a
+        }
+
+        private fun upperBound(lo: Int, hi: Int, depth: Int, ch: Char): Int {
+            var a = lo
+            var b = hi
+            val target = ch.code
+            while (a < b) {
+                val mid = (a + b) ushr 1
+                if (keyAt(mid, depth) <= target) a = mid + 1 else b = mid
+            }
+            return a
+        }
+    }
+
+    /**
+     * Decodes [points] (a flat `[x0, y0, x1, y1, …]` in key-width units, NaN marking a character the user
+     * chose deliberately) into the most plausible complete dictionary words of the same length.
+     *
+     * [typed] is what the keyboard resolved the taps to; it is only consulted for the NaN positions, whose
+     * character is treated as certain. Returns at most [maxResults] candidates, cheapest first.
+     */
+    fun decode(
+        points: FloatArray,
+        typed: String,
+        index: PrefixIndex,
+        layout: KeyProximityInfo.Layout,
+        maxResults: Int,
+    ): List<Candidate> {
+        val length = points.size / 2
+        if (length == 0 || length > MAX_LENGTH || typed.length != length || index.words.isEmpty()) {
+            return emptyList()
+        }
+
+        // Beam state, kept in parallel primitive arrays: dictionary range plus accumulated cost.
+        var los = IntArray(1)
+        var his = IntArray(1) { index.words.size }
+        var costs = FloatArray(1)
+        var count = 1
+
+        val alternatives = IntArray(KEY_ALTERNATIVES)
+        val nextLos = IntArray(BEAM_WIDTH * KEY_ALTERNATIVES)
+        val nextHis = IntArray(BEAM_WIDTH * KEY_ALTERNATIVES)
+        val nextCosts = FloatArray(BEAM_WIDTH * KEY_ALTERNATIVES)
+
+        for (depth in 0 until length) {
+            val x = points[depth * 2]
+            val y = points[depth * 2 + 1]
+            val isExact = x.isNaN() || y.isNaN()
+            val nearest = if (isExact) 0f else layout.nearestSqDistance(x, y)
+            val altCount = if (isExact) 0 else layout.nearestKeys(x, y, alternatives)
+            var produced = 0
+
+            for (s in 0 until count) {
+                if (isExact) {
+                    // A deliberately chosen character: no neighbours, no cost.
+                    val packed = index.narrow(los[s], his[s], depth, typed[depth].lowercaseChar())
+                    if (packed >= 0) {
+                        nextLos[produced] = (packed ushr 32).toInt()
+                        nextHis[produced] = (packed and 0xFFFFFFFFL).toInt()
+                        nextCosts[produced] = costs[s]
+                        produced++
+                    }
+                    continue
+                }
+                for (a in 0 until altCount) {
+                    val keyIndex = alternatives[a]
+                    val ch = layout.codeAt(keyIndex).toChar().lowercaseChar()
+                    val packed = index.narrow(los[s], his[s], depth, ch)
+                    if (packed < 0) continue
+                    nextLos[produced] = (packed ushr 32).toInt()
+                    nextHis[produced] = (packed and 0xFFFFFFFFL).toInt()
+                    nextCosts[produced] = costs[s] + (layout.sqDistance(keyIndex, x, y) - nearest)
+                    produced++
+                }
+            }
+
+            if (produced == 0) return emptyList()
+
+            // Keep the cheapest BEAM_WIDTH paths. A partial selection sort is fine at this size and avoids
+            // allocating boxed comparators on a per-keystroke path.
+            val keep = minOf(produced, BEAM_WIDTH)
+            for (i in 0 until keep) {
+                var best = i
+                for (j in i + 1 until produced) if (nextCosts[j] < nextCosts[best]) best = j
+                if (best != i) {
+                    val tl = nextLos[i]; nextLos[i] = nextLos[best]; nextLos[best] = tl
+                    val th = nextHis[i]; nextHis[i] = nextHis[best]; nextHis[best] = th
+                    val tc = nextCosts[i]; nextCosts[i] = nextCosts[best]; nextCosts[best] = tc
+                }
+            }
+            if (los.size < keep) {
+                los = IntArray(keep); his = IntArray(keep); costs = FloatArray(keep)
+            }
+            for (i in 0 until keep) {
+                los[i] = nextLos[i]; his[i] = nextHis[i]; costs[i] = nextCosts[i]
+            }
+            count = keep
+        }
+
+        // A surviving range starts with the word that is exactly `length` characters long, if one exists —
+        // shorter-or-equal entries sort first among words sharing the prefix.
+        val out = ArrayList<Candidate>(minOf(count, maxResults))
+        for (s in 0 until count) {
+            val word = index.words[los[s]]
+            if (word.length == length) out.add(Candidate(word, costs[s]))
+            if (out.size >= maxResults) break
+        }
+        return out
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchTrace.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchTrace.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.ime.nlp.latin
+
+/**
+ * Where the finger actually landed for each character of the word currently being composed (issue #242).
+ *
+ * The keyboard resolves every tap to its nearest key and then throws the coordinate away, which is exactly
+ * the information the autocorrect needs: "n" tapped dead-centre and "n" tapped halfway towards "m" are the
+ * same character but very different evidence. This object keeps that evidence for the composing word so
+ * [TouchBeamDecoder] can decode from the taps instead of from the already-resolved string.
+ *
+ * **The trace is self-validating.** [pointsFor] hands out coordinates only if the recorded characters still
+ * spell the word the caller is asking about. Anything that desyncs the two — pasting, moving the cursor, a
+ * hardware keyboard, a glide commit, text arriving from dictation — simply yields null and the caller falls
+ * back to the classic edit-distance path. That is far more robust than trying to hook every such site.
+ *
+ * Written from the UI thread (touch handling), read from a background coroutine (suggestion generation),
+ * hence the synchronization.
+ */
+object TouchTrace {
+
+    /** Longest word we keep evidence for; beyond this the trace is dropped and autocorrect falls back. */
+    private const val MAX_LENGTH = 48
+
+    /** Marks a character the user chose deliberately (long-press accent picker), where position is moot. */
+    private const val EXACT = Float.NaN
+
+    private val chars = StringBuilder(MAX_LENGTH)
+    private val xs = FloatArray(MAX_LENGTH)
+    private val ys = FloatArray(MAX_LENGTH)
+
+    // Position of the touch-down that is about to produce a character, in key-width units. Set when a key
+    // is pressed and consumed when the resulting character is committed, so the coordinate travels with the
+    // keystroke without threading it through the whole input-event plumbing.
+    private var pendingX = EXACT
+    private var pendingY = EXACT
+    private var hasPending = false
+
+    /** A character key was pressed at the given raw touch position (pixels). */
+    @Synchronized
+    fun pendingTap(xPx: Float, yPx: Float) {
+        val p = KeyProximityInfo.normalize(xPx, yPx)
+        if (p == null) {
+            markPendingExact()
+            return
+        }
+        pendingX = p[0]
+        pendingY = p[1]
+        hasPending = true
+    }
+
+    /**
+     * The next character comes from a deliberate choice rather than a plain tap (long-press accent picker,
+     * a popup selection). Recorded as certain: the decoder will not consider neighbouring keys for it.
+     */
+    @Synchronized
+    fun markPendingExact() {
+        pendingX = EXACT
+        pendingY = EXACT
+        hasPending = true
+    }
+
+    /**
+     * A character reached the editor. Appends it together with the pending tap position; a character with
+     * no pending tap (hardware keyboard, injected text) invalidates the trace, because from that point on
+     * the coordinates no longer line up with the word.
+     */
+    @Synchronized
+    fun commit(text: String) {
+        if (!hasPending || text.length != 1 || chars.length >= MAX_LENGTH) {
+            reset()
+            return
+        }
+        val i = chars.length
+        chars.append(text[0])
+        xs[i] = pendingX
+        ys[i] = pendingY
+        hasPending = false
+    }
+
+    /** A backspace removed the last character; drop its evidence so the trace stays aligned. */
+    @Synchronized
+    fun pop() {
+        hasPending = false
+        if (chars.isNotEmpty()) chars.setLength(chars.length - 1)
+    }
+
+    /** Forget everything — the composing word ended or the editor state changed underneath us. */
+    @Synchronized
+    fun reset() {
+        chars.setLength(0)
+        hasPending = false
+    }
+
+    /**
+     * Tap positions for [word], or null when the trace does not describe exactly that word (and the caller
+     * must fall back). Returns a flat `[x0, y0, x1, y1, …]` copy so the decoder is unaffected by further
+     * typing while it runs; NaN marks a character the user picked deliberately.
+     */
+    @Synchronized
+    fun pointsFor(word: String): FloatArray? {
+        if (word.isEmpty() || word.length != chars.length) return null
+        for (i in word.indices) {
+            if (!word[i].equals(chars[i], ignoreCase = true)) return null
+        }
+        val out = FloatArray(word.length * 2)
+        for (i in word.indices) {
+            out[i * 2] = xs[i]
+            out[i * 2 + 1] = ys[i]
+        }
+        return out
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/text/keyboard/TextKeyboardLayout.kt
@@ -69,6 +69,7 @@ import dev.patrickgold.florisboard.ime.input.InputEventDispatcher
 import dev.patrickgold.florisboard.ime.keyboard.ComputingEvaluator
 import dev.patrickgold.florisboard.ime.keyboard.FlorisImeSizing
 import dev.patrickgold.florisboard.ime.nlp.latin.KeyProximityInfo
+import dev.patrickgold.florisboard.ime.nlp.latin.TouchTrace
 import dev.patrickgold.florisboard.ime.keyboard.KeyboardMode
 import dev.patrickgold.florisboard.ime.keyboard.SpaceBarMode
 import dev.patrickgold.florisboard.ime.popup.ExceptionsForKeyCodes
@@ -582,6 +583,12 @@ private class TextKeyboardLayoutController(
         val key = keyboard.getKeyForPos(event.getX(pointer.index), event.getY(pointer.index))
         if (key != null && key.isEnabled) {
             key.computedDataOnDown = key.computedData
+            // Remember where the finger actually landed, not just which key won (issue #242). The autocorrect
+            // decodes from these coordinates, so a tap halfway between two keys stays distinguishable from a
+            // dead-centre one. Consumed when the resulting character reaches the editor.
+            if (key.computedData.type == KeyType.CHARACTER) {
+                TouchTrace.pendingTap(event.getX(pointer.index), event.getY(pointer.index))
+            }
             pointer.pressedKeyInfo = inputEventDispatcher.sendDown(
                 data = key.computedData,
                 onLongPress = onLongPress@ {
@@ -704,6 +711,10 @@ private class TextKeyboardLayoutController(
                         }
                     } else {
                         inputEventDispatcher.sendCancel(activeKey.computedDataOnDown)
+                        // Picked from the long-press popup (an accent, a variant): a deliberate choice, not a
+                        // tap that might have missed. Recorded as certain so autocorrect never second-guesses
+                        // it against neighbouring keys (issue #242).
+                        TouchTrace.markPendingExact()
                         inputEventDispatcher.sendDownUp(retData)
                     }
                 } else {

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchBeamDecoderTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/TouchBeamDecoderTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 DevEmperor (Dictate)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package dev.patrickgold.florisboard.ime.nlp.latin
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the beam decoder (issue #242). The interesting failure modes are all in the range narrowing —
+ * off-by-one binary-search bounds and the packed `(lo, hi)` long — and in whether a tap that drifts towards
+ * a neighbouring key actually changes the decoded word.
+ */
+class TouchBeamDecoderTest {
+
+    // A miniature QWERTY in key-width units, matching how KeyProximityInfo normalizes a real layout.
+    private companion object {
+        const val ROW_HEIGHT = 1.15f
+        val ROWS = listOf("qwertyuiop" to 0.0f, "asdfghjkl" to 0.5f, "zxcvbnm" to 1.5f)
+
+        val LAYOUT: KeyProximityInfo.Layout = run {
+            val codes = ArrayList<Int>()
+            val xs = ArrayList<Float>()
+            val ys = ArrayList<Float>()
+            ROWS.forEachIndexed { rowIndex, (row, offset) ->
+                row.forEachIndexed { i, ch ->
+                    codes.add(ch.code)
+                    xs.add(offset + i)
+                    ys.add(rowIndex * ROW_HEIGHT)
+                }
+            }
+            KeyProximityInfo.Layout(codes.toIntArray(), xs.toFloatArray(), ys.toFloatArray())
+        }
+
+        val WORDS = arrayOf("car", "cart", "cat", "cats", "held", "hello", "help", "jello")
+        val INDEX = TouchBeamDecoder.PrefixIndex(WORDS)
+
+        fun centreOf(ch: Char): Pair<Float, Float> {
+            ROWS.forEachIndexed { rowIndex, (row, offset) ->
+                val i = row.indexOf(ch)
+                if (i >= 0) return (offset + i) to (rowIndex * ROW_HEIGHT)
+            }
+            error("no key for '$ch'")
+        }
+
+        /** Taps dead-centre on every character of [word]. */
+        fun tapsFor(word: String): FloatArray {
+            val out = FloatArray(word.length * 2)
+            word.forEachIndexed { i, ch ->
+                val (x, y) = centreOf(ch)
+                out[i * 2] = x
+                out[i * 2 + 1] = y
+            }
+            return out
+        }
+
+        fun decode(points: FloatArray, typed: String, maxResults: Int = 5) =
+            TouchBeamDecoder.decode(points, typed, INDEX, LAYOUT, maxResults)
+    }
+
+    @Test
+    fun narrowSelectsTheContiguousRangeForAPrefix() {
+        // "car", "cart" share "car"; "cat", "cats" share "cat".
+        val all = INDEX.narrow(0, WORDS.size, depth = 0, ch = 'c')
+        assertEquals(0, (all ushr 32).toInt())
+        assertEquals(4, (all and 0xFFFFFFFFL).toInt())
+
+        val car = INDEX.narrow(0, 4, depth = 2, ch = 'r')
+        assertEquals(0, (car ushr 32).toInt())
+        assertEquals(2, (car and 0xFFFFFFFFL).toInt())
+
+        val cat = INDEX.narrow(0, 4, depth = 2, ch = 't')
+        assertEquals(2, (cat ushr 32).toInt())
+        assertEquals(4, (cat and 0xFFFFFFFFL).toInt())
+    }
+
+    @Test
+    fun narrowReportsNoMatchInsteadOfAnEmptyRange() {
+        assertEquals(-1L, INDEX.narrow(0, WORDS.size, depth = 0, ch = 'z'))
+        // "car" has no fourth character, so asking past its end must not match it.
+        assertEquals(-1L, INDEX.narrow(0, 1, depth = 3, ch = 'x'))
+    }
+
+    @Test
+    fun narrowSkipsWordsThatEndBeforeTheQueriedDepth() {
+        // Within "cat", "cats" the shorter entry sorts first and has no character at depth 3.
+        val packed = INDEX.narrow(2, 4, depth = 3, ch = 's')
+        assertEquals(3, (packed ushr 32).toInt())
+        assertEquals(4, (packed and 0xFFFFFFFFL).toInt())
+    }
+
+    @Test
+    fun cleanTapsDecodeToTheTypedWord() {
+        val result = decode(tapsFor("hello"), "hello")
+        assertTrue(result.isNotEmpty(), "expected at least one candidate")
+        assertEquals("hello", result.first().word)
+        assertEquals(0.0f, result.first().cost, 1e-4f)
+    }
+
+    @Test
+    fun aTapDriftingTowardsANeighbourDecodesToTheNeighbourWord() {
+        // Start from "hello" but place the first tap almost on top of "j", which turns it into "jello".
+        val points = tapsFor("hello")
+        val (jx, jy) = centreOf('j')
+        points[0] = jx
+        points[1] = jy
+
+        val result = decode(points, "hello")
+        assertEquals("jello", result.first().word)
+    }
+
+    @Test
+    fun aTapBetweenTwoKeysKeepsBothWordsButPrefersTheCloserOne() {
+        val points = tapsFor("hello")
+        val (hx, hy) = centreOf('h')
+        val (jx, jy) = centreOf('j')
+        // Slightly closer to 'h' than to 'j'.
+        points[0] = hx + (jx - hx) * 0.45f
+        points[1] = hy + (jy - hy) * 0.45f
+
+        val result = decode(points, "hello")
+        val words = result.map { it.word }
+        assertTrue(words.contains("hello") && words.contains("jello"), "both readings should survive: $words")
+        // The winning reading is by definition free: cost is the excess over the *nearest* key, and 'h' is
+        // still the nearest. What the coordinate buys is how cheap the runner-up is.
+        assertEquals("hello", result.first().word)
+        assertEquals(0.0f, result.first().cost, 1e-4f)
+        assertTrue(result.first().cost < result[1].cost)
+    }
+
+    @Test
+    fun theCloserATapDriftsTheCheaperTheAlternativeReadingBecomes() {
+        // This is the whole point of decoding from coordinates rather than from the resolved string: two
+        // taps that both resolve to 'h' must not look identical to the decoder.
+        fun jelloCostAt(fraction: Float): Float {
+            val points = tapsFor("hello")
+            val (hx, hy) = centreOf('h')
+            val (jx, jy) = centreOf('j')
+            points[0] = hx + (jx - hx) * fraction
+            points[1] = hy + (jy - hy) * fraction
+            return decode(points, "hello").first { it.word == "jello" }.cost
+        }
+
+        val deadCentre = jelloCostAt(0.0f)
+        val drifting = jelloCostAt(0.45f)
+        assertTrue(
+            drifting < deadCentre,
+            "a tap drifting towards 'j' must make \"jello\" cheaper ($drifting vs $deadCentre)",
+        )
+    }
+
+    @Test
+    fun deliberatelyChosenCharactersAreNotSecondGuessed() {
+        // NaN marks a character picked from the long-press popup: only the typed character is allowed, so
+        // even coordinates that would otherwise favour "jello" must still yield "hello".
+        val points = tapsFor("hello")
+        points[0] = Float.NaN
+        points[1] = Float.NaN
+
+        val result = decode(points, "hello")
+        assertEquals(listOf("hello"), result.map { it.word })
+        assertEquals(0.0f, result.first().cost, 1e-4f)
+    }
+
+    @Test
+    fun noDictionaryWordOfThatLengthYieldsNothing() {
+        // "hel" is a prefix of real words but is not itself one.
+        assertTrue(decode(tapsFor("hel"), "hel").isEmpty())
+    }
+
+    @Test
+    fun candidatesComeBackCheapestFirstAndAreCapped() {
+        val points = tapsFor("cat")
+        val result = decode(points, "cat", maxResults = 2)
+        assertTrue(result.size <= 2)
+        for (i in 1 until result.size) {
+            assertTrue(result[i - 1].cost <= result[i].cost, "candidates must be ordered by cost")
+        }
+    }
+
+    @Test
+    fun mismatchedInputIsRejectedRatherThanDecodedWrongly() {
+        // typed and points must describe the same number of characters
+        assertTrue(decode(tapsFor("hello"), "help").isEmpty())
+        assertTrue(TouchBeamDecoder.decode(FloatArray(0), "", INDEX, LAYOUT, 5).isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #242.

Reworks the Latin autocorrect to decode from **where the fingers actually landed** instead of from the already-resolved key sequence, plus a German noun-capitalisation pass that fell out of the same analysis.

## Why

The old corrector took the resolved string ("hte") and looked for dictionary words within one edit. That discards the only evidence that matters — how close each tap was to its key — and can only reach words one edit away. Measured against the shipping dictionary, the intended word is inside that candidate set **52.7 %** of the time. A beam search over the taps finds it **99.7 %** of the time.

| | English | German | Turkish |
|---|---|---|---|
| before | 88.4 % | 85.7 % | 80.9 % |
| after | **97.9 %** | **95.3 %** | **92.3 %** |

(share of typed words that end up correct, simulated at a realistic mis-tap rate on each language's real layout and shipped dictionary)

## How

- **`TouchTrace`** — records the tap position behind each keystroke of the composing word. Self-validating: it hands out coordinates only if the recorded characters still spell the word being asked about, so pasting, cursor jumps, a hardware keyboard, glide and dictated text all fall back to the classic path without needing a hook each.
- **`TouchBeamDecoder`** — walks the taps left to right, considers the 6 nearest keys per tap, keeps the 24 cheapest paths and drops any path that is no longer a dictionary prefix. Pruning uses a plain sorted word array — a path is a `[lo, hi)` range and extending it narrows the range by binary search — so no trie, no extra memory, no string allocation in the loop. Cost is the *excess* distance over the closest key, so a dead-centre tap is free.
- **`KeyProximityInfo`** — now normalized to key widths and hands the decoder an immutable snapshot.
- The legacy constants and code path are untouched, so behaviour without tap evidence is unchanged.

## Auto-commit is gated on tap evidence

Worth calling out, because the obvious version of this is wrong. Dropping the old `hadCandidatesBefore` gate is worth +1.04 pp **on typos** — but measured against *correctly typed out-of-dictionary words* (names), the same change silently rewrites **30.4 %** of them (`sarahs`→`daraus`, `pete`→`peter`), against 19.5 % before. 

Gating on the beam's tap cost instead fixes both ends:

| auto-commit rule | typos fixed | correctly typed names mangled |
|---|---|---|
| old gate | — | 19.5 % |
| gate simply removed | 99.6 % | 30.4 % |
| **tap cost ≤ 0.8** | **95.0 %** | **~0 %** |

Suggestions are always shown; only the silent swap is gated.

## German noun capitalisation

Typing a noun lowercase produced no correction at all — the case-folded index reports "haus" as known, so the correction path was skipped and "Haus" only appeared as a prefix completion, which is never auto-committed. ~31 % of typed German words are affected.

The dictionary already encodes which words qualify: `generate.py` stores a word capitalised exactly when the case oracle rejects its lowercase spelling. Legitimately-lowercase words (`essen`, `laufen`, `recht`, `sie`) are stored lowercase and are left alone. Hangs off the **existing** "Auto-capitalization" preference rather than adding one — anyone typing all-lowercase on purpose has already turned that off.

## Verification

11 new unit tests on the range narrowing and decode behaviour; full suite 76 tests, 0 failures.

Driven on an A55 (German QWERTZ) via `adb input touchscreen swipe`, which allows tapping deliberately off-centre:

| input | result |
|---|---|
| `Hsllo` (tap inside `s`, near the `a` boundary) | **Hallo** offered bold |
| `Eime` (tap inside `m`, near the `n` boundary) | **Eine** bold, committed on space — the case the old prefix gate suppressed |
| `Dads` dead-centre | `Dass`/`Das`/`Fass` offered, **none bold**, survives space |
| `Jannis` dead-centre | untouched |
| `Fur` | **Für** bold — umlaut restoration (#219) and #150 intact |
| `das haus` | `haus` tappable, **Haus** bold → "Das Haus" |
| `wir essen` | nothing bold, stays lowercase |

## Not covered

- Thresholds are tuned on simulation, not telemetry — real-world feel over a longer session is still unproven.
- Typing latency was not profiled on device (the decoder is ~1.6 ms/word in *Python*; Kotlin should be far below that, but it is unmeasured here).
- The remaining items from #242 — next-word prediction (top-3 covers ~44 % of continuations with bigrams that are already loaded) and personalisation — are untouched.
